### PR TITLE
Notifications

### DIFF
--- a/misc/demo/app/DemoApp.js
+++ b/misc/demo/app/DemoApp.js
@@ -15,6 +15,7 @@ import Breadcrumb from './pages/Breadcrumb';
 import Spinners from './pages/Spinners';
 import Menu from './pages/Menu';
 import Images from './pages/Images';
+import Notifications from './pages/Notifications';
 
 const DemoApp = () =>
   <Router history={browserHistory}>
@@ -32,6 +33,7 @@ const DemoApp = () =>
       <Route path="/menus" component={Menu} />
       <Route path="/images" component={Images} />
       <Route path="/modals" component={Modals} />
+      <Route path="/notifications" component={Notifications} />
     </Route>
   </Router>;
 

--- a/misc/demo/app/pages/Modals/index.js
+++ b/misc/demo/app/pages/Modals/index.js
@@ -76,30 +76,30 @@ const Modals = () =>
       <ExampleDirectional />
     </div>
 
-    <div className="slds-p-around--xx-large">
-      <h2 className="slds-text-heading--medium">Modal</h2>
-      <PropTypeDescription code={modalCode} />
-    </div>
+    <PropTypeDescription
+      code={modalCode}
+      header="### Modal"
+    />
 
-    <div className="slds-p-around--xx-large">
-      <h2 className="slds-text-heading--medium">Modal Header</h2>
-      <PropTypeDescription code={modalHeaderCode} />
-    </div>
+    <PropTypeDescription
+      code={modalHeaderCode}
+      header="### Modal Header"
+    />
 
-    <div className="slds-p-around--xx-large">
-      <h2 className="slds-text-heading--medium">Modal Content</h2>
-      <PropTypeDescription code={modalContentCode} />
-    </div>
+    <PropTypeDescription
+      code={modalContentCode}
+      header="### Modal Content"
+    />
 
-    <div className="slds-p-around--xx-large">
-      <h2 className="slds-text-heading--medium">Modal Footer</h2>
-      <PropTypeDescription code={modalFooterCode} />
-    </div>
+    <PropTypeDescription
+      code={modalFooterCode}
+      header="### Modal Footer"
+    />
 
-    <div className="slds-p-around--xx-large">
-      <h2 className="slds-text-heading--medium">Backdrop</h2>
-      <PropTypeDescription code={backdropCode} />
-    </div>
+    <PropTypeDescription
+      code={backdropCode}
+      header="### Backdrop"
+    />
   </div>;
 
 export default Modals;

--- a/misc/demo/app/pages/Notifications/ExampleAlertError.js
+++ b/misc/demo/app/pages/Notifications/ExampleAlertError.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Notification, IconSVG } from 'react-lds';
+
+const ExampleAlertError = () => (
+  <Notification alert title="Error" theme="error texture">
+    <h2>
+      <IconSVG sprite="utility" icon="ban" size="small" className="slds-m-right--x-small" />
+      Your browser is currently not supported. Your Salesforce may be degraded. <a href="#">More Information</a>
+    </h2>
+  </Notification>
+);
+
+export default ExampleAlertError;

--- a/misc/demo/app/pages/Notifications/ExampleAlertNormal.js
+++ b/misc/demo/app/pages/Notifications/ExampleAlertNormal.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Notification } from 'react-lds';
+
+const ExampleAlertNormal = () => (
+  <Notification alert title="Info" theme="info texture">Base System Alert</Notification>
+);
+
+export default ExampleAlertNormal;

--- a/misc/demo/app/pages/Notifications/ExampleAlertOffline.js
+++ b/misc/demo/app/pages/Notifications/ExampleAlertOffline.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Notification, IconSVG } from 'react-lds';
+
+const ExampleAlertOffline = () => (
+  <Notification alert title="Offline" theme="offline texture">
+    <IconSVG sprite="utility" icon="offline" size="small" className="slds-m-right--x-small" />
+    Your browser is currently not supported. Your Salesforce may be degraded. <a href="#">More Information</a>
+  </Notification>
+);
+
+export default ExampleAlertOffline;

--- a/misc/demo/app/pages/Notifications/ExampleAlertSuccess.js
+++ b/misc/demo/app/pages/Notifications/ExampleAlertSuccess.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Notification, IconSVG } from 'react-lds';
+
+const ExampleAlertSuccess = () => (
+  <Notification alert title="Success" theme="success texture">
+    <IconSVG sprite="utility" icon="connected_apps" size="small" className="slds-m-right--x-small" />
+    Scheduled Maintenance Notification: Sunday March 15, 8:00 AM–10:00 PST <a href="#">More Information</a>
+  </Notification>
+);
+
+export default ExampleAlertSuccess;

--- a/misc/demo/app/pages/Notifications/ExampleModalToast.js
+++ b/misc/demo/app/pages/Notifications/ExampleModalToast.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+  Modal,
+  ModalHeader,
+  ModalContent,
+  ModalFooter,
+  Backdrop,
+  Button,
+ Notification,
+  Grid,
+  Column,
+  IconSVG,
+} from 'react-lds';
+
+const ExampleModalToast = () => (
+  <div className="demo-modal">
+    <Modal large open>
+      <ModalHeader title="Modal Header">
+        <Notification toast title="Error" theme="error">
+          <Grid className="slds-notify__content">
+            <Column className="slds-m-right--small" no-flex>
+              <IconSVG sprite="utility" icon="warning" size="small" />
+            </Column>
+            <Column className="slds-m-right--small" middle>
+              <h2 className="slds-text-heading--small">
+                You&#x27;ve encountered some errors when trying to save edits to Samuel Smith.
+              </h2>
+            </Column>
+          </Grid>
+        </Notification>
+      </ModalHeader>
+      <ModalContent>
+        <div>
+          <p>Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam
+          incididunt duis in sint irure nisi. Mollit officia cillum Lorem ullamco minim nostrud elit officia tempor esse
+          quis. Cillum sunt ad dolore quis aute consequat ipsum magna exercitation reprehenderit magna. Tempor cupidatat
+          consequat elit dolor adipisicing.</p> <p>Dolor eiusmod sunt ex incididunt cillum quis nostrud velit duis sit
+          officia. Lorem aliqua enim laboris do dolor eiusmod officia. Mollit incididunt nisi consectetur esse laborum
+          eiusmod pariatur proident. Eiusmod et adipisicing culpa deserunt nostrud ad veniam nulla aute est. Labore esse
+          esse cupidatat amet velit id elit consequat minim ullamco mollit enim excepteur ea.</p>
+        </div>
+      </ModalContent>
+      <ModalFooter>
+        <Button variation="neutral" title="Cancel" />
+        <Button variation="brand" title="Save" />
+      </ModalFooter>
+    </Modal>
+    <Backdrop open />
+  </div>
+);
+
+export default ExampleModalToast;

--- a/misc/demo/app/pages/Notifications/ExamplePrompt.js
+++ b/misc/demo/app/pages/Notifications/ExamplePrompt.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Prompt } from 'react-lds';
+
+const ExamplePrompt = () => (
+  <Prompt
+    title="Service Unavailable"
+    label="prompt-heading-id"
+    buttonText="Okay"
+    description="prompt-message-wrapper"
+    open
+  >
+    <p>Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco
+    deserunt aute id consequat veniam incididunt duis in sint irure nisi.</p>
+  </Prompt>
+);
+
+export default ExamplePrompt;

--- a/misc/demo/app/pages/Notifications/ExamplePromptTouch.js
+++ b/misc/demo/app/pages/Notifications/ExamplePromptTouch.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { PromptForTouch, Button } from 'react-lds';
+
+const ExamplePromptTouch = () => (
+  <PromptForTouch open >
+    <Button variation="neutral" title="Upload from Device" />
+    <Button variation="neutral" title="Select a Salesforce File" />
+    <Button variation="neutral" title="Cancel" />
+  </PromptForTouch>
+);
+
+export default ExamplePromptTouch;

--- a/misc/demo/app/pages/Notifications/ExamplePromptTouchHeader.js
+++ b/misc/demo/app/pages/Notifications/ExamplePromptTouchHeader.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { PromptForTouch, Button } from 'react-lds';
+
+const ExamplePromptTouchHeader = () => (
+  <PromptForTouch open title="Select a New Record Type">
+    <Button variation="neutral" title="Simple" />
+    <Button variation="neutral" title="Advanced" />
+    <Button variation="neutral" title="Partner" />
+    <Button variation="neutral" title="Partner" />
+    <Button variation="neutral" title="Person Accounts" />
+    <Button variation="neutral" title="Cancel" />
+  </PromptForTouch>
+);
+
+export default ExamplePromptTouchHeader;

--- a/misc/demo/app/pages/Notifications/ExamplePromptTouchIcon.js
+++ b/misc/demo/app/pages/Notifications/ExamplePromptTouchIcon.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { PromptForTouch, Button, Icon } from 'react-lds';
+
+const icon = (<Icon sldsClasses={['m-bottom--x-small', 'p-around--x-small']} sprite="action" icon="share_thanks" />);
+
+const ExamplePromptTouchIcon = () => (
+  <PromptForTouch
+    open
+    headerIcon={icon}
+    title="Your Feedback is Valueable"
+    tagline="We’re glad to hear you’re enjoying the app! Your input helps drive
+    our products. Would you mind taking a moment to give us feedback through the
+    App Store? We really appreciate your support."
+  >
+    <Button variation="brand" title="Rate Salesforce1" />
+    <Button variation="neutral" title="No, Thanks" />
+    <Button variation="neutral" title="Remind Me Later" />
+  </PromptForTouch>
+);
+
+export default ExamplePromptTouchIcon;

--- a/misc/demo/app/pages/Notifications/ExamplePromptTouchTagline.js
+++ b/misc/demo/app/pages/Notifications/ExamplePromptTouchTagline.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { PromptForTouch, Button } from 'react-lds';
+
+const ExamplePromptTouchTagline = () => (
+  <PromptForTouch open title="Delete Account" tagline="Are you sure you want to delete this account?">
+    <Button variation="destructive" title="Delete" />
+    <Button variation="neutral" title="Cancel" />
+  </PromptForTouch>
+);
+
+export default ExamplePromptTouchTagline;

--- a/misc/demo/app/pages/Notifications/ExampleToastError.js
+++ b/misc/demo/app/pages/Notifications/ExampleToastError.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Notification, Grid, Column, IconSVG } from 'react-lds';
+
+const ExampleToastError = () => (
+  <Notification toast title="Error" theme="error">
+    <Grid className="slds-notify__content">
+      <Column className="slds-m-right--small" no-flex>
+        <IconSVG sprite="utility" icon="warning" size="small" />
+      </Column>
+      <Column className="slds-m-right--small" middle>
+        <h2 className="slds-text-heading--small">
+          You encountered some errors when trying to save edits to Samuel Smith.
+        </h2>
+      </Column>
+    </Grid>
+  </Notification>
+);
+
+export default ExampleToastError;

--- a/misc/demo/app/pages/Notifications/ExampleToastErrorDetails.js
+++ b/misc/demo/app/pages/Notifications/ExampleToastErrorDetails.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Notification, Grid, Column, IconSVG } from 'react-lds';
+
+const ExampleToastErrorDetails = () => (
+  <Notification toast title="Error" theme="info">
+    <Grid className="slds-notify__content">
+      <Column className="slds-m-right--small" no-flex>
+        <IconSVG sprite="utility" icon="warning" size="small" />
+      </Column>
+      <Column className="slds-m-right--small" middle>
+        <h2 className="slds-text-heading--small">
+          You&#x27;ve encountered some errors when trying to save edits to Samuel Smith.
+        </h2>
+        <p>Here&#x27;s some detail of what happened, being very descriptive and transparent.</p>
+      </Column>
+    </Grid>
+  </Notification>
+);
+
+export default ExampleToastErrorDetails;

--- a/misc/demo/app/pages/Notifications/ExampleToastNormal.js
+++ b/misc/demo/app/pages/Notifications/ExampleToastNormal.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Notification } from 'react-lds';
+
+const ExampleToastNormal = () => (
+  <Notification toast title="Info" theme="info">
+    <div className="slds-notify__content">
+      <h2 className="slds-text-heading--small">Base Toast</h2>
+    </div>
+  </Notification>
+);
+
+export default ExampleToastNormal;

--- a/misc/demo/app/pages/Notifications/ExampleToastSuccess.js
+++ b/misc/demo/app/pages/Notifications/ExampleToastSuccess.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Notification, Grid, Column, IconSVG } from 'react-lds';
+
+const ExampleToastSuccess = () => (
+  <Notification toast title="Success" theme="success">
+    <Grid className="slds-notify__content">
+      <Column className="slds-m-right--small" no-flex>
+        <IconSVG sprite="utility" icon="notification" size="small" />
+      </Column>
+      <Column className="slds-m-right--small" middle>
+        <h2 className="slds-text-heading--small">
+          Your new contact <a href="#">Sara Smith</a> was successfully created.
+        </h2>
+      </Column>
+    </Grid>
+  </Notification>
+);
+
+export default ExampleToastSuccess;

--- a/misc/demo/app/pages/Notifications/ExampleToastWarning.js
+++ b/misc/demo/app/pages/Notifications/ExampleToastWarning.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Notification } from 'react-lds';
+
+const ExampleToastWarning = () => (
+  <Notification toast title="Warning" theme="warning">
+    <div className="slds-notify__content">
+      <h2 className="slds-text-heading--small">Oops, you&#x27;ve missed some required form inputs.</h2>
+    </div>
+  </Notification>
+);
+
+export default ExampleToastWarning;

--- a/misc/demo/app/pages/Notifications/index.js
+++ b/misc/demo/app/pages/Notifications/index.js
@@ -1,0 +1,221 @@
+import React from 'react';
+
+import CodeExample from './../../components/CodeExample';
+import PropTypeDescription from './../../components/PropTypeDescription';
+import Masthead from './../../Masthead';
+import HeaderIcon from './../../HeaderIcon';
+
+import ExampleAlertNormal from './ExampleAlertNormal';
+import exampleAlertNormalCode from '!raw!./ExampleAlertNormal';
+import ExampleAlertError from './ExampleAlertError';
+import exampleAlertErrorCode from '!raw!./ExampleAlertError';
+import ExampleAlertOffline from './ExampleAlertOffline';
+import exampleAlertOfflineCode from '!raw!./ExampleAlertOffline';
+import ExampleAlertSuccess from './ExampleAlertSuccess';
+import exampleAlertSuccessCode from '!raw!./ExampleAlertSuccess';
+
+import ExampleToastNormal from './ExampleToastNormal';
+import exampleToastNormalCode from '!raw!./ExampleToastNormal';
+import ExampleToastError from './ExampleToastError';
+import exampleToastErrorCode from '!raw!./ExampleToastError';
+import ExampleToastErrorDetails from './ExampleToastErrorDetails';
+import exampleToastErrorDetailsCode from '!raw!./ExampleToastErrorDetails';
+import ExampleToastWarning from './ExampleToastWarning';
+import exampleToastWarningCode from '!raw!./ExampleToastWarning';
+import ExampleToastSuccess from './ExampleToastSuccess';
+import exampleToastSuccessCode from '!raw!./ExampleToastSuccess';
+
+import ExamplePrompt from './ExamplePrompt';
+import examplePromptCode from '!raw!./ExamplePrompt';
+
+import ExamplePromptTouch from './ExamplePromptTouch';
+import examplePromptTouchCode from '!raw!./ExamplePromptTouch';
+import ExamplePromptTouchHeader from './ExamplePromptTouchHeader';
+import examplePromptTouchHeaderCode from '!raw!./ExamplePromptTouchHeader';
+import ExamplePromptTouchTagline from './ExamplePromptTouchTagline';
+import examplePromptTouchTaglineCode from '!raw!./ExamplePromptTouchTagline';
+import ExamplePromptTouchIcon from './ExamplePromptTouchIcon';
+import examplePromptTouchIconCode from '!raw!./ExamplePromptTouchIcon';
+
+
+import ExampleModalToast from './ExampleModalToast';
+import exampleModalToastCode from '!raw!./ExampleModalToast';
+
+import promptCode from '!raw!react-lds/components/Notifications/Prompt';
+import promptForTouchCode from '!raw!react-lds/components/Notifications/PromptForTouch';
+import notificationCode from '!raw!react-lds/components/Notifications/Notification';
+
+require('./notifications.scss');
+
+const Notifications = () => (
+  <div>
+    <Masthead figure={<HeaderIcon />} title="Notifications" />
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Base Alert"
+        code={exampleAlertNormalCode}
+      />
+      <div className="demo-notifications">
+        <ExampleAlertNormal />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Error Alert"
+        code={exampleAlertErrorCode}
+      />
+      <div className="demo-notifications">
+        <ExampleAlertError />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Offline Alert"
+        code={exampleAlertOfflineCode}
+      />
+      <div className="demo-notifications">
+        <ExampleAlertOffline />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Success Alert"
+        code={exampleAlertSuccessCode}
+      />
+      <div className="demo-notifications">
+        <ExampleAlertSuccess />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Normal Toast"
+        code={exampleToastNormalCode}
+      />
+      <div className="demo-notifications">
+        <ExampleToastNormal />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Error Toast"
+        code={exampleToastErrorCode}
+      />
+      <div className="demo-notifications">
+        <ExampleToastError />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Warning Toast"
+        code={exampleToastWarningCode}
+      />
+      <div className="demo-notifications">
+        <ExampleToastWarning />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Success Toast"
+        code={exampleToastSuccessCode}
+      />
+      <div className="demo-notifications">
+        <ExampleToastSuccess />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Error with Details Toast"
+        code={exampleToastErrorDetailsCode}
+      />
+      <div className="demo-notifications">
+        <ExampleToastErrorDetails />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Example Prompt"
+        code={examplePromptCode}
+      />
+      <div className="demo-modal">
+        <ExamplePrompt />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Example PromptForTouch"
+        code={examplePromptTouchCode}
+      />
+      <div className="demo-modal">
+        <ExamplePromptTouch />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Example PromptForTouch with Header"
+        code={examplePromptTouchHeaderCode}
+      />
+      <div className="demo-modal">
+        <ExamplePromptTouchHeader />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Example PromptForTouch with Tagline"
+        code={examplePromptTouchTaglineCode}
+      />
+      <div className="demo-modal">
+        <ExamplePromptTouchTagline />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Example PromptForTouch with Icon"
+        code={examplePromptTouchIconCode}
+      />
+      <div className="demo-modal">
+        <ExamplePromptTouchIcon />
+      </div>
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Example Modal Toast"
+        code={exampleModalToastCode}
+      />
+      <div className="demo-modal">
+        <ExampleModalToast />
+      </div>
+    </div>
+
+    <PropTypeDescription
+      code={notificationCode}
+      header="### Notification"
+    />
+
+    <PropTypeDescription
+      code={promptCode}
+      header="### Prompt"
+    />
+
+    <PropTypeDescription
+      code={promptForTouchCode}
+      header="### Prompt For Touch"
+    />
+
+  </div>
+);
+
+export default Notifications;

--- a/misc/demo/app/pages/Notifications/notifications.scss
+++ b/misc/demo/app/pages/Notifications/notifications.scss
@@ -1,0 +1,19 @@
+
+.demo-modal {
+  height: 640px;
+  position: relative;
+}
+
+.demo-modal .slds-modal,
+.demo-modal .slds-backdrop {
+  position: absolute;
+}
+
+.demo-notifications {
+  height: 2rem;
+  position: relative;
+}
+
+.demo-notifications .slds-notify_container {
+  position: absolute !important;
+}

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -34,6 +34,7 @@ Button.propTypes = {
   variation: React.PropTypes.oneOf([
     'neutral',
     'brand',
+    'destructive',
     'icon-border-filled',
     'icon-container',
     'icon-inverse',

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,36 +1,41 @@
 import React from 'react';
 import IconSVG from './IconSVG';
 
-import classNames from 'classnames';
-import { iconName } from './util';
+import { iconClass } from './util';
+import { prefixable } from '../../decorators';
 
-const Icon = ({ sprite, icon, title, circle, background, size, div }) => {
-  const backgroundClass = !background ? `slds-icon-${sprite}-${iconName(sprite, icon)}` : `slds-icon-${background}`;
+export const Icon = (props) => {
+  const { sprite, icon, title, circle, background, size, div, prefix } = props;
+  const backgroundClass = !background ? `icon-${sprite}-${iconClass(sprite, icon)}` : `icon-${background}`;
 
-  const classes = {
-    'slds-icon_container': true,
-    'slds-icon_container--circle': circle,
-    [`${backgroundClass}`]: true,
-  };
+  const sldsClasses = [
+    { icon_container: true },
+    { 'icon_container--circle': circle },
+    { [`${backgroundClass}`]: true },
+  ];
 
   const WrapperElement = div ? 'div' : 'span';
 
   return (
-    <WrapperElement className={classNames(classes)} title={title}>
+    <WrapperElement className={prefix(sldsClasses, props)} title={title}>
       <IconSVG sprite={sprite} icon={icon} size={size} />
-      <span className="slds-assistive-text">{title}</span>
+      <span className={prefix(['assistive-text'])}>{title}</span>
     </WrapperElement>
   );
 };
 
 Icon.propTypes = {
+  /**
+   * the prefix function from the prefixable HOC
+   */
+  prefix: React.PropTypes.func,
   sprite: React.PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']).isRequired,
   icon: React.PropTypes.string.isRequired,
   title: React.PropTypes.string,
   circle: React.PropTypes.bool,
   div: React.PropTypes.bool,
   background: React.PropTypes.string,
-  size: React.PropTypes.oneOf(['x-small', 'small', 'large']),
+  size: React.PropTypes.oneOf(['x-small', 'small', 'medium', 'large']),
 };
 
-export default Icon;
+export default prefixable(Icon);

--- a/src/components/Icon/__tests__/Icon.spec.js
+++ b/src/components/Icon/__tests__/Icon.spec.js
@@ -1,47 +1,47 @@
 jest.unmock('../Icon');
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import Icon from '../Icon';
 
 describe('<Icon />', () => {
   it('wraps the icon in an `slds-icon_container`', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" />);
-    expect(icon.hasClass('slds-icon_container')).toBeTruthy();
+    const icon = mount(<Icon sprite="standard" icon="account" />);
+    expect(icon.find('.icon_container').length).toBe(1);
   });
 
   it('does displays a square background as default', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" />);
-    expect(icon.hasClass('slds-icon_container--circle')).toBeFalsy();
+    const icon = mount(<Icon sprite="standard" icon="account" />);
+    expect(icon.find('.icon_container').hasClass('icon_container--circle')).toBeFalsy();
   });
 
   it('supports circular backgrounds', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" circle />);
-    expect(icon.hasClass('slds-icon_container--circle')).toBeTruthy();
+    const icon = mount(<Icon sprite="standard" icon="account" circle />);
+    expect(icon.find('.icon_container').hasClass('icon_container--circle')).toBeTruthy();
   });
 
   it('can have a title for accessebility purposes', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" title="foobar" />);
+    const icon = mount(<Icon sprite="standard" icon="account" title="foobar" />);
     expect(icon.find('[title="foobar"]').length).toBe(1);
   });
 
   it('defaults to an `span` container', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" />);
-    expect(icon.is('span')).toBeTruthy();
+    const icon = mount(<Icon sprite="standard" icon="account" />);
+    expect(icon.find('.icon_container').is('span')).toBeTruthy();
   });
 
   it('supports also `div` containers', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" div />);
-    expect(icon.is('div')).toBeTruthy();
+    const icon = mount(<Icon sprite="standard" icon="account" div />);
+    expect(icon.find('.icon_container').is('div')).toBeTruthy();
   });
 
   it('sets the default icon background', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" />);
-    expect(icon.hasClass('slds-icon-standard-account')).toBeTruthy();
+    const icon = mount(<Icon sprite="action" icon="foo_bar" />);
+    expect(icon.find('.icon_container').hasClass('icon-action-foo-bar')).toBeTruthy();
   });
 
   it('allows a background override', () => {
-    const icon = shallow(<Icon sprite="standard" icon="account" background="custom-custom90" />);
-    expect(icon.hasClass('slds-icon-custom-custom90')).toBeTruthy();
+    const icon = mount(<Icon sprite="standard" icon="account" background="custom-custom90" />);
+    expect(icon.find('.icon_container').hasClass('icon-custom-custom90')).toBeTruthy();
   });
 });

--- a/src/components/Icon/util.js
+++ b/src/components/Icon/util.js
@@ -1,3 +1,5 @@
 const iconName = (sprite, icon) => (sprite === 'custom' ? `custom${icon}` : icon);
 
-export { iconName };
+const iconClass = (sprite, icon) => iconName(sprite, icon.replace(/_/g, '-'));
+
+export { iconClass, iconName };

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -23,14 +23,14 @@ export const Modal = (props) => {
   ];
 
   const childrenWithProps = [...children].map((child, i) => {
-    const childName = child.type.displayName;
+    const childName = !!child ? child.type.displayName : null;
 
     if (childName === 'ModalHeader') {
       return React.cloneElement(child, {
         key: i,
         label,
         prompt,
-        uncloseable: prompt,
+        uncloseable: child.props.uncloseable !== undefined ? child.props.uncloseable : prompt,
       });
     }
 
@@ -76,7 +76,7 @@ Modal.propTypes = {
    */
   description: React.PropTypes.string,
   /**
-   * whether a container is a dialog (optional when <Modal prompt>). Needed for PromptForTouch and ModalPrompt
+   * whether a container is a dialog (optional when `<Modal prompt>`). Needed for PromptForTouch and ModalPrompt
    */
   dialog: React.PropTypes.bool,
   /**

--- a/src/components/Modal/ModalHeader.js
+++ b/src/components/Modal/ModalHeader.js
@@ -42,9 +42,9 @@ export class ModalHeader extends React.Component {
     return (
       <div className={this.props.prefix(sldsClasses, this.props)}>
         {!this.props.uncloseable ? this.getCloseButton() : null}
+        {this.props.children}
         {this.props.title ? this.getTitle() : null}
         {this.props.tagline ? this.getTagline() : null}
-        {this.props.children}
       </div>
     );
   }
@@ -60,11 +60,11 @@ ModalHeader.propTypes = {
    */
   children: React.PropTypes.node,
   /**
-   * the heading id. gets passed down from <Modal>
+   * the heading id. gets passed down from `Modal`
    */
   label: React.PropTypes.string,
   /**
-   * renders a prompt header. Gets passed down from <Modal prompt>
+   * renders a prompt header. Gets passed down from `Modal prompt`
    */
   prompt: React.PropTypes.bool,
   /**
@@ -76,7 +76,7 @@ ModalHeader.propTypes = {
    */
   title: React.PropTypes.string,
   /**
-   * hides the close-button (gets passed down from <Modal prompt>)
+   * hides the close-button (gets passed down from `Modal prompt`)
    */
   uncloseable: React.PropTypes.bool,
 };

--- a/src/components/Notifications/Notification.js
+++ b/src/components/Notifications/Notification.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Button, ButtonIcon } from 'react-lds';
+import { flavorable, prefixable, themeable } from '../../decorators';
+
+function getThemeName(themeStr) {
+  return /\stexture/.test(themeStr) ? `${themeStr.split(' ')[0]}` : `${themeStr}`;
+}
+
+export const Notification = (props) => {
+  const {
+    children,
+    title,
+    prefix,
+    toast, // eslint-disable-line react/prop-types
+    theme, // eslint-disable-line react/prop-types
+  } = props;
+
+  const sldsClasses = [
+    'notify',
+  ];
+
+  return (
+    <div className={prefix(['notify_container'])}>
+      <div className={prefix(sldsClasses, props)} role="alert">
+        <Button
+          icon
+          variation={getThemeName(theme) !== 'warning' ? 'icon-inverse' : undefined}
+          sldsClasses={['notify__close']}
+        >
+          <ButtonIcon sprite="utility" icon="close" size={!!toast ? 'large' : undefined} />
+          <span className={prefix(['assistive-text'])}>Close</span>
+        </Button>
+        <span className={prefix(['assistive-text'])}>{title}</span>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+Notification.flavors = [
+  'alert',
+  'toast',
+];
+
+Notification.propTypes = {
+  /**
+   * the prefix function from the prefixable HOC
+   */
+  prefix: React.PropTypes.func,
+  /**
+   * the alert title (will be rendered as assistiveText)
+   */
+  title: React.PropTypes.string.isRequired,
+  /**
+   * the alert content
+   */
+  children: React.PropTypes.node.isRequired,
+};
+
+export default prefixable(themeable(
+  flavorable(Notification, 'notify')
+));

--- a/src/components/Notifications/Prompt.js
+++ b/src/components/Notifications/Prompt.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Modal, ModalHeader, ModalContent, ModalFooter, Backdrop, Button } from 'react-lds';
+
+const Prompt = (props) => (
+  <div>
+    <Modal label={props.label} description={props.description} open={props.open} dialog prompt>
+      <ModalHeader title={props.title} />
+      <ModalContent>{props.children}</ModalContent>
+      <ModalFooter default>
+        <Button variation="neutral" title={props.buttonText} />
+      </ModalFooter>
+    </Modal>
+    <Backdrop open={props.open} />
+  </div>
+);
+
+Prompt.propTypes = {
+  /**
+   * the prompt label
+   */
+  label: React.PropTypes.string.isRequired,
+  /**
+   * the prompt description
+   */
+  description: React.PropTypes.string.isRequired,
+  /**
+   * the prompt closing button text
+   */
+  buttonText: React.PropTypes.string.isRequired,
+  /**
+   * the prompt content
+   */
+  title: React.PropTypes.string.isRequired,
+  /**
+   * opens the prompt
+   */
+  open: React.PropTypes.bool,
+  /**
+   * the prompt content
+   */
+  children: React.PropTypes.node.isRequired,
+};
+
+export default Prompt;

--- a/src/components/Notifications/PromptForTouch.js
+++ b/src/components/Notifications/PromptForTouch.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Modal, ModalHeader, ModalContent, Backdrop } from 'react-lds';
+
+const header = (title, tagline, headerIcon) => {
+  const hasHeader = !!title || !!tagline || !!headerIcon;
+  const Header = (
+    <ModalHeader title={title} tagline={tagline} uncloseable>
+      {headerIcon}
+    </ModalHeader>
+  );
+  return hasHeader ? Header : null;
+};
+
+const PromptForTouch = (props) => (
+  <div>
+    <Modal label={props.label} dialog open={props.open}>
+      {header(props.title, props.tagline, props.headerIcon)}
+      <ModalContent menu>{props.children}</ModalContent>
+    </Modal>
+    <Backdrop open={props.open} />
+  </div>
+);
+
+PromptForTouch.propTypes = {
+  /**
+   * the prompt label
+   */
+  label: React.PropTypes.string,
+  /**
+   * the prompt header-icon
+   */
+  headerIcon: React.PropTypes.node,
+  /**
+   * the prompt title
+   */
+  title: React.PropTypes.string,
+  /**
+   * the prompt tagline
+   */
+  tagline: React.PropTypes.string,
+  /**
+   * opens the prompt
+   */
+  open: React.PropTypes.bool,
+  /**
+   * the prompt content
+   */
+  children: React.PropTypes.node.isRequired,
+};
+
+export default PromptForTouch;

--- a/src/components/Notifications/__tests__/Notification.spec.js
+++ b/src/components/Notifications/__tests__/Notification.spec.js
@@ -1,0 +1,33 @@
+jest.unmock('../Notification');
+
+import React from 'react';
+import Notification from '../Notification';
+import { mount } from 'enzyme';
+
+describe('Notification', () => {
+  it('renders the correct markup', () => {
+    const wrapper = mount(<Notification title="foo" alert><p>Foobar</p></Notification>);
+    const container = wrapper.find('.notify_container');
+    const notification = container.find('.notify');
+    expect(container.length).toBe(1);
+    expect(notification.length).toBe(1);
+    expect(notification.find('button').length).toBe(1);
+    expect(notification.find('button > .assistive-text').length).toBe(1);
+    expect(notification.find('> .assistive-text').length).toBe(1);
+    expect(notification.contains(<p>Foobar</p>)).toBeTruthy();
+  });
+
+  it('renders non-inverse buttons for the warning theme', () => {
+    const info = mount(<Notification title="foo" toast theme="info"><p>Foobar</p></Notification>);
+    const warning = mount(<Notification title="foo" toast theme="warning"><p>Foobar</p></Notification>);
+    expect(info.find('button').hasClass('button--icon-inverse')).toBeTruthy();
+    expect(warning.find('button').hasClass('button--icon-inverse')).toBeFalsy();
+  });
+
+  it('renders large close icons for toasts', () => {
+    const toast = mount(<Notification title="foo" toast><p>Foobar</p></Notification>);
+    const alert = mount(<Notification title="foo" alert><p>Foobar</p></Notification>);
+    expect(alert.find('button svg').hasClass('button__icon--large')).toBeFalsy();
+    expect(toast.find('button svg').hasClass('button__icon--large')).toBeTruthy();
+  });
+});

--- a/src/components/Notifications/index.js
+++ b/src/components/Notifications/index.js
@@ -1,0 +1,9 @@
+import Notification from './Notification';
+import Prompt from './Prompt';
+import PromptForTouch from './PromptForTouch';
+
+export {
+  Notification,
+  Prompt,
+  PromptForTouch,
+};

--- a/src/decorators/themeable.js
+++ b/src/decorators/themeable.js
@@ -35,7 +35,7 @@ function getThemeClassName(theme) {
 
   if (/\stexture/.test(theme)) {
     classes = [`theme--${theme.split(' ')[0]}`, 'theme--alert-texture'];
-  } else {
+  } else if (theme !== undefined) {
     classes = [`theme--${theme}`];
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,16 @@ import { Breadcrumb } from './components/Breadcrumb';
 import { Spinner } from './components/Spinner';
 import { DropdownMenu, DropdownMenuList, DropdownMenuListItem, Picklist } from './components/Menu';
 import Avatar from './components/Images';
+import { Notification, Prompt, PromptForTouch } from './components/Notifications';
 
 export {
   Box,
   Icon,
   IconSVG,
   MediaObject,
+  Notification,
+  Prompt,
+  PromptForTouch,
   PageHeader,
   Button,
   ButtonGroup,


### PR DESCRIPTION
**Alerts**
- [x] Wrapper-Komponenten
- [x] `<Button>`: Support für `slds-button--icon-inverse` & `classNames` bevor benutzbar (#21)
- [x] `Icon-SVG`: `prefixable`-Dekorator
- [x] `<Notification>`-Komponente mit Flavors für Toasts und Alerts statt einzelne Komponenten?

**Toast**
- [x] Toast ersetzt `h2` mit `slds-notify__content`
- [x] Toast erlaubt zusätzliche Klassen auf `slds-notify__content`
- [x] Toast entfernt `--icon-inverse` von Button im Warning-Theme

**Prompt**
- [x] Benötigt `<Modal>`

**Prompt for Touch**
- [x] Benötigt `<Modal>`

**Modal Toast**
- [x] Benötigt `<Modal>
