### PR TITLE
decorate IconSVG component with prefixable

### DIFF
--- a/src/components/Button/ButtonIcon.js
+++ b/src/components/Button/ButtonIcon.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import IconSVG from '../Icon/IconSVG';
 
-import classNames from 'classnames';
-
 const ButtonIcon = ({ sprite, icon, position, size }) => {
-  const classes = {
-    'slds-button__icon': true,
-    [`slds-button__icon--${position}`]: !!position,
-    [`slds-button__icon--${size}`]: size,
-  };
+  const classes = [
+    'button__icon',
+    { [`button__icon--${position}`]: !!position },
+    { [`button__icon--${size}`]: size },
+  ];
 
   return (
-    <IconSVG sprite={sprite} icon={icon} cssClasses={classNames(classes)} />
+    <IconSVG sprite={sprite} icon={icon} cssClasses={classes} />
   );
 };
 

--- a/src/components/Icon/IconSVG.js
+++ b/src/components/Icon/IconSVG.js
@@ -1,38 +1,37 @@
 import React from 'react';
 
-import classNames from 'classnames';
+import prefixable from './../../decorators/prefixable';
 import { iconName } from './util';
 
-const IconSVG = ({ sprite, icon, background, size, cssClasses }, { assetBasePath }) => {
-  let classes = {
-    'slds-icon': true,
-    [`slds-icon-${background}`]: !!background,
-    [`slds-icon--${size}`]: !!size,
-  };
+const IconSVG = ({ prefix, sprite, icon, background, size, cssClasses }, { assetBasePath }) => {
+  let classes = [
+    'icon',
+    { [`icon-${background}`]: !!background },
+    { [`icon--${size}`]: !!size },
+  ];
 
   if (cssClasses) {
     classes = cssClasses;
-  } else {
-    classes = classNames(classes);
   }
 
   return (
-    <svg aria-hidden="true" className={classes}>
+    <svg aria-hidden="true" className={prefix(classes)}>
       <use xlinkHref={`${assetBasePath}/assets/icons/${sprite}-sprite/svg/symbols.svg#${iconName(sprite, icon)}`} />
     </svg>
   );
 };
 
 IconSVG.propTypes = {
+  prefix: React.PropTypes.func.isRequired,
   sprite: React.PropTypes.string.isRequired,
   icon: React.PropTypes.string.isRequired,
   background: React.PropTypes.string,
   size: React.PropTypes.string,
-  cssClasses: React.PropTypes.string,
+  cssClasses: React.PropTypes.array,
 };
 
 IconSVG.contextTypes = {
   assetBasePath: React.PropTypes.string.isRequired,
 };
 
-export default IconSVG;
+export default prefixable(IconSVG);

--- a/src/components/Icon/__tests__/IconSVG.spec.js
+++ b/src/components/Icon/__tests__/IconSVG.spec.js
@@ -1,24 +1,24 @@
 jest.unmock('../IconSVG');
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import IconSVG from '../IconSVG';
 
 describe('<IconSVG />', () => {
-  const context = { assetBasePath: '' };
+  const context = { assetBasePath: '', cssPrefix: 'slds-' };
 
   it('has `slds-icon`-class', () => {
-    const icon = shallow(<IconSVG sprite="standard" icon="account" />, { context });
-    expect(icon.hasClass('slds-icon')).toBeTruthy();
+    const icon = mount(<IconSVG sprite="standard" icon="account" />, { context });
+    expect(icon.find('svg').hasClass('slds-icon')).toBeTruthy();
   });
 
   it('supports different sizes', () => {
-    const icon = shallow(<IconSVG sprite="standard" icon="account" size="large" />, { context });
-    expect(icon.hasClass('slds-icon--large')).toBeTruthy();
+    const icon = mount(<IconSVG sprite="standard" icon="account" size="large" />, { context });
+    expect(icon.find('svg').hasClass('slds-icon--large')).toBeTruthy();
   });
 
   it('can display an icon with a custom background color', () => {
-    const icon = shallow(<IconSVG sprite="standard" icon="account" background="custom-custom89" />, { context });
-    expect(icon.hasClass('slds-icon-custom-custom89')).toBeTruthy();
+    const icon = mount(<IconSVG sprite="standard" icon="account" background="custom-custom89" />, { context });
+    expect(icon.find('svg').hasClass('slds-icon-custom-custom89')).toBeTruthy();
   });
 });


### PR DESCRIPTION
add our prefix decorator to the `IconSVG` component and modify the `ButtonIcon` directive to use it.

`classes` prop is now an array because the `prefix` method needs an array and not the previously produced string from the `classnames` package. 
