### PR TITLE
Use `export from` in src

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": "airbnb",
+  "parser": "babel-eslint",
   "env": {
     "jest": true,
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "Konstantin Krauss <konstantin@propertybase.com> (http://www.propertybase.com)",
     "Christian Schultheiss <christian@propertybase.com> (http://www.propertybase.com)",
     "Ben Bieker <ben@propertybase.com> (http://www.propertybase.com)",
-    "Philipp Frank <philipp@propertybase.com> (http://www.propertybase.com)"
+    "Philipp Frank <philipp@propertybase.com> (http://www.propertybase.com)",
+    "Felix Spöttel <felix@propertybase.com> (http://www.propertybase.com)"
   ],
   "repository": {
     "type": "git",

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,5 +1,1 @@
-import Badge from './Badge';
-
-export {
-  Badge as default,
-};
+export Badge from './Badge';

--- a/src/components/Box/index.js
+++ b/src/components/Box/index.js
@@ -1,3 +1,1 @@
-import Box from './Box';
-
-export default Box;
+export Box from './Box';

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -1,5 +1,1 @@
-import Breadcrumb from './Breadcrumb';
-
-export {
-  Breadcrumb,
-};
+export Breadcrumb from './Breadcrumb';

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,7 +1,2 @@
-import Button from './Button';
-import ButtonIcon from './ButtonIcon';
-
-export {
-  Button,
-  ButtonIcon,
-};
+export Button from './Button';
+export ButtonIcon from './ButtonIcon';

--- a/src/components/ButtonGroup/index.js
+++ b/src/components/ButtonGroup/index.js
@@ -1,5 +1,1 @@
-import ButtonGroup from './ButtonGroup';
-
-export {
-  ButtonGroup,
-};
+export ButtonGroup from './ButtonGroup';

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,5 +1,1 @@
-import Card from './Card';
-
-export {
-  Card,
-};
+export Card from './Card';

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -1,9 +1,3 @@
-import Table from './Table';
-import Row from './Row';
-import Cell from './Cell';
-
-export {
-  Table,
-  Row,
-  Cell,
-};
+export Table from './Table';
+export Row from './Row';
+export Cell from './Cell';

--- a/src/components/Grid/index.js
+++ b/src/components/Grid/index.js
@@ -1,9 +1,3 @@
-import Grid from './Grid';
-import Column from './Column';
-import Container from './Container';
-
-export {
-  Grid,
-  Column,
-  Container,
-};
+export Grid from './Grid';
+export Column from './Column';
+export Container from './Container';

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,7 +1,2 @@
-import Icon from './Icon';
-import IconSVG from './IconSVG';
-
-export {
-  Icon,
-  IconSVG,
-};
+export Icon from './Icon';
+export IconSVG from './IconSVG';

--- a/src/components/Images/index.js
+++ b/src/components/Images/index.js
@@ -1,3 +1,1 @@
-import Avatar from './Avatar';
-
-export default Avatar;
+export Avatar from './Avatar';

--- a/src/components/MediaObject/index.js
+++ b/src/components/MediaObject/index.js
@@ -1,3 +1,1 @@
-import MediaObject from './MediaObject';
-
-export default MediaObject;
+export MediaObject from './MediaObject';

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,11 +1,4 @@
-import DropdownMenu from './DropdownMenu';
-import DropdownMenuList from './DropdownMenuList';
-import DropdownMenuListItem from './DropdownMenuListItem';
-import Picklist from './Picklist';
-
-export {
-  DropdownMenu,
-  DropdownMenuList,
-  DropdownMenuListItem,
-  Picklist,
-};
+export DropdownMenu from './DropdownMenu';
+export DropdownMenuList from './DropdownMenuList';
+export DropdownMenuListItem from './DropdownMenuListItem';
+export Picklist from './Picklist';

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,13 +1,5 @@
-import Backdrop from './Backdrop';
-import Modal from './Modal';
-import ModalContent from './ModalContent';
-import ModalHeader from './ModalHeader';
-import ModalFooter from './ModalFooter';
-
-export {
-  Backdrop,
-  Modal,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-};
+export Backdrop from './Backdrop';
+export Modal from './Modal';
+export ModalContent from './ModalContent';
+export ModalHeader from './ModalHeader';
+export ModalFooter from './ModalFooter';

--- a/src/components/Notifications/index.js
+++ b/src/components/Notifications/index.js
@@ -1,9 +1,3 @@
-import Notification from './Notification';
-import Prompt from './Prompt';
-import PromptForTouch from './PromptForTouch';
-
-export {
-  Notification,
-  Prompt,
-  PromptForTouch,
-};
+export Notification from './Notification';
+export Prompt from './Prompt';
+export PromptForTouch from './PromptForTouch';

--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -1,9 +1,3 @@
-import PageHeaderBase from './PageHeaderBase';
-import RecordHome from './RecordHome';
-import ObjectHome from './ObjectHome';
-
-export {
-  PageHeaderBase,
-  RecordHome,
-  ObjectHome,
-};
+export PageHeaderBase from './PageHeaderBase';
+export RecordHome from './RecordHome';
+export ObjectHome from './ObjectHome';

--- a/src/components/Spinner/index.js
+++ b/src/components/Spinner/index.js
@@ -1,5 +1,1 @@
-import Spinner from './Spinner';
-
-export {
-  Spinner,
-};
+export Spinner from './Spinner';

--- a/src/components/Tab/index.js
+++ b/src/components/Tab/index.js
@@ -1,5 +1,1 @@
-import Tab from './Tab';
-
-export {
-  Tab,
-};
+export Tab from './Tab';

--- a/src/decorators/index.js
+++ b/src/decorators/index.js
@@ -1,13 +1,5 @@
-import themeable from './themeable';
-import prefixable from './prefixable';
-import sizeable from './sizeable';
-import flavorable from './flavorable';
-import variationable from './variationable';
-
-export {
-  themeable,
-  prefixable,
-  sizeable,
-  flavorable,
-  variationable,
-};
+export themeable from './themeable';
+export prefixable from './prefixable';
+export sizeable from './sizeable';
+export flavorable from './flavorable';
+export variationable from './variationable';

--- a/src/index.js
+++ b/src/index.js
@@ -1,54 +1,17 @@
-import Box from './components/Box';
-import { Table, Row, Cell } from './components/DataTable';
-import MediaObject from './components/MediaObject';
-import { PageHeaderBase, RecordHome, ObjectHome } from './components/PageHeader';
-import { Icon, IconSVG } from './components/Icon';
-import { Backdrop, Modal, ModalContent, ModalHeader, ModalFooter } from './components/Modal';
-import { Button, ButtonIcon } from './components/Button';
-import { ButtonGroup } from './components/ButtonGroup';
-import { Tab } from './components/Tab';
-import Badge from './components/Badge';
-import { Grid, Column, Container } from './components/Grid';
-import { Breadcrumb } from './components/Breadcrumb';
-import { Spinner } from './components/Spinner';
-import { DropdownMenu, DropdownMenuList, DropdownMenuListItem, Picklist } from './components/Menu';
-import Avatar from './components/Images';
-import { Notification, Prompt, PromptForTouch } from './components/Notifications';
-import { Card } from './components/Card';
-
-export {
-  Box,
-  Icon,
-  IconSVG,
-  MediaObject,
-  Notification,
-  Prompt,
-  PromptForTouch,
-  PageHeaderBase,
-  RecordHome,
-  ObjectHome,
-  Button,
-  ButtonGroup,
-  ButtonIcon,
-  Badge,
-  Grid,
-  Column,
-  Container,
-  Breadcrumb,
-  Spinner,
-  Table,
-  Row,
-  Cell,
-  DropdownMenu,
-  DropdownMenuList,
-  DropdownMenuListItem,
-  Picklist,
-  Avatar,
-  Backdrop,
-  Modal,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  Tab,
-  Card,
-};
+export * from './components/Badge';
+export * from './components/Box';
+export * from './components/Breadcrumb';
+export * from './components/Button';
+export * from './components/Card';
+export * from './components/ButtonGroup';
+export * from './components/DataTable';
+export * from './components/Grid';
+export * from './components/Icon';
+export * from './components/Images';
+export * from './components/MediaObject';
+export * from './components/Menu';
+export * from './components/Modal';
+export * from './components/Notifications';
+export * from './components/PageHeader';
+export * from './components/Tab';
+export * from './components/Spinner';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,1 @@
-import uniqueId from './uniqueId';
-
-export {
-  uniqueId,
-};
+export uniqueId from './uniqueId';


### PR DESCRIPTION
This branch uses the proposed `export from` statement to reduce boilerplate in `/src` and add consistency to exporting-logic.

Conventions:
- `src/index.js` is just a collection of `export * from ./components/{Component}`-statements
- Each folder in components has an index.js that is composed of `export {Name} from ./{Component}`-statements
