### PR TITLE
Badges: Use decorators, add test

### DIFF
--- a/misc/demo/app/pages/Badge/ExampleNormal.js
+++ b/misc/demo/app/pages/Badge/ExampleNormal.js
@@ -5,9 +5,9 @@ import { Badge } from 'react-lds';
 const ExampleNormal = () =>
   <div>
     <Badge label="Label" />
-    <Badge variation="default" label="Label" />
-    <Badge variation="shade" label="Label" />
-    <Badge variation="inverse" label="Label" />
+    <Badge theme="default" label="Label" />
+    <Badge theme="shade" label="Label" />
+    <Badge theme="inverse" label="Label" />
   </div>;
 
 export default ExampleNormal;

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -1,21 +1,20 @@
 import React from 'react';
+import { prefixable, themeable } from '../../decorators';
 
-import classNames from 'classnames';
-
-const Badge = ({ variation, label }) => {
-  const classes = {
-    'slds-badge': true,
-    [`slds-theme--${variation}`]: variation,
-  };
-
-  return (
-    <span className={classNames(classes)}>{label}</span>
-  );
-};
+export const Badge = (props) =>
+  <span className={props.prefix(['badge'], props)}>{props.label}</span>;
 
 Badge.propTypes = {
-  variation: React.PropTypes.oneOf(['default', 'shade', 'inverse']),
+  /**
+   * the prefix function from the prefixable HOC
+   */
+  prefix: React.PropTypes.func,
+  /**
+   * the badge label
+   */
   label: React.PropTypes.string.isRequired,
 };
 
-export default Badge;
+export default prefixable(
+  themeable(Badge)
+);

--- a/src/components/Badge/__tests__/Badge.spec.js
+++ b/src/components/Badge/__tests__/Badge.spec.js
@@ -1,0 +1,12 @@
+jest.unmock('../Badge');
+
+import React from 'react';
+import { mount } from 'enzyme';
+import Badge from '../Badge';
+
+describe('<Badge>', () => {
+  it('should render a label', () => {
+    const wrapper = mount(<Badge label="Foo" />);
+    expect(wrapper.find('.badge').text()).toBe('Foo');
+  });
+});


### PR DESCRIPTION
- Use `prefixable`-decorator
- Use `themeable`-decorator
- Add unit-tests for `<Badge>`
- Update `<Badge>`-Examples
