### PR TITLE
We need react as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,12 @@
   },
   "homepage": "https://github.com/propertybase/react-lds#readme",
   "license": "MIT",
+  "peerDependencies": {
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
+  },
   "dependencies": {
     "classnames": "2.2.5",
-    "react": "15.1.0",
     "react-click-outside": "2.1.0"
   },
   "devDependencies": {
@@ -57,7 +60,6 @@
     "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.1.0",
     "react-docgen": "2.8.2",
-    "react-dom": "15.1.0",
     "react-hot-loader": "3.0.0-beta.1",
     "react-router": "2.4.1",
     "recast": "0.11.6",


### PR DESCRIPTION
to avoid loading multiple copies of react. See https://nodejs.org/en/blog/npm/peer-dependencies/

Every installed react plugin must use the same instance from the parent npm package
