### PR TITLE
Fix Travis Token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,11 @@ language: node_js
 cache:
   bundler: true
   directories:
-    - node_modules
+  - node_modules
 node_js:
-  - "6"
-env:
-  global:
-  - secure: 2YydrbNYnLgEeOcEEw5KlEOm1a8Yn1GxN8ue723l8C/XuaySCp1pIluVUgNwgRUjTfW7YH+/PdxizbA4QsSrmA/tdK1KpZvwmUiNa3vLsHq9xJxRPE09pwV7dsD8nixZTDb54o9u+Y8pjiWboFgY7f4CDAay6qmpy0weBE/nACLMOpPJtP4RTKj3yaB2ZRGx3WGWBZWCZYwFK+ET4hvU/pv7OLOO1T0SVCx7i/Wz6DW5pvnz/GTppQrxfyYkWLQLk1qRjk+EG4RK5cuFaovf1OkE9QEnP1AgVhvgI0iwiYq+E9CkVR3StVGcmcH6XjPYb6NlnKqoitgI+gfpsWbMNi/Gse9GRtxCFHhLl7tVYnaxGJxwqgRlHciFq64KggLhvEJMgJ/zqdfMplYmG4tpLppXxM15r6RD8q87OtmbP8fkyM5kdZ6LbWib0sG6YopfO/xGW0lnrk0skwKFOWwZyQ5hRm0MvwOQOFYMtXrHUSiyBTKrCCsNIvfMrBM6b7oAHP1yX//Osb5/H9vOIyLi5a7U9LSl3koSolJkPodSJwTSOuhGfZBKSekBppZOiN9ia0bmgE4xwH3jHIG61QsBTOceNvHe2imQh1YDUA1Qjc4omFUmce9NB4MsMpEbq5/1wjgeqaeToHtFPp6TeRf0cSQV8DmbPbFJCxiWohNK18M=
+- '6'
 after_success:
-- npm run deploy
+- bash deploy_docs.sh
 deploy:
   provider: npm
   email: technik@propertybase.com
@@ -18,3 +15,6 @@ deploy:
   on:
     tags: true
     repo: propertybase/react-lds
+env:
+  global:
+  - GITHUB_REPO: propertybase/react-lds

--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -3,9 +3,9 @@
 set -o errexit -o nounset
 
 # Do nothing if the commit was not pushed to master
-if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "master" ]
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]
 then
-  echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
+  echo "This commit was either a pull request or made against the $TRAVIS_BRANCH and not the master! No deploy!"
   exit 0
 fi
 
@@ -20,12 +20,9 @@ npm run build:docs
 rev=$(git rev-parse --short HEAD)
 cd ./docs/build
 git init
-git remote add upstream "https://$GH_TOKEN@github.com/propertybase/react-lds.git"
-git fetch upstream
-git reset upstream/gh-pages
 
 # Add all changes in push them to gh-pages
 touch .
 git add -A .
 git commit -m "rebuild pages at ${rev}"
-git push -q upstream HEAD:gh-pages
+git push --force --quiet "https://${GITHUB_TOKEN}@github.com/${GITHUB_REPO}.git" master:gh-pages > /dev/null 2>&1

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "build:babel": "babel ./src --ignore *.spec.js --out-dir ./dist",
     "build:copy-files": "cp ./src/styles.css ./dist/; cp ./README.md ./dist/",
     "build:docs": "rm -rf ./docs/build; webpack --config ./docs/webpack.prod.config",
-    "deploy": "bash deploy.sh",
     "prebuild": "rm -rf ./dist",
     "prepublish": "npm run prebuild; npm run build",
     "pretest": "npm run lint"


### PR DESCRIPTION
This works when `GITHUB_TOKEN` is set via the web interface for Travis, but I can't for the life of me figure out how to add an encrypted token for this specific repository. These are the steps I've taken:

- Get an access-token for `propertybase-ci` (this token works when set in Web UI)
- Install the travis gem, log into propertybase-ci by running `travis login --pro`
- Encrypt the token by running `travis encrypt "GITHUB_TOKEN={token}"` I also tried explicitely setting the repo by passing `-r propertybase/react-lds`, does not make a difference.
- Add the token to `env.global`

If someone could point me in the right direction on this, it would be awesome. Maybe this is related to the repo being public and hosted on `travis-ci.com` instead of `travis-ci.org`. I tried to test it with `travis login` (to get a token for the public CI) but `propertybase-ci` needs to authorize with `travis-ci.org` first and I want to confirm that this is ok before giving the access.

**Edit**: I implemented a similiar configuration with a personal open-source project hosted on `travis-ci.org` and it works without issues.
