### PR TITLE
Add callback on lookup resultAdd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+* Add callback when result is added to Lookup. It can manipulate the result that is added
+* Clean up callback bindings in Lookup & reduce debounce delay by 100ms
+
 ## 1.0.6
 * Deprecate DockedComposer
 * Add checkboxes

--- a/docs/src/app/pages/Lookups/ExampleMulti.js
+++ b/docs/src/app/pages/Lookups/ExampleMulti.js
@@ -61,6 +61,9 @@ const ExampleMulti = () => {
     console.log(selectedItems);
   };
 
+
+  const onAdd = (C, item) => React.cloneElement(C, { className: `yalla-${item.id}` });
+
   return (
     <Lookup
       id="lookup-multi"
@@ -70,6 +73,7 @@ const ExampleMulti = () => {
       load={loadFunction}
       multi
       onChange={onChange}
+      onResultAdd={onAdd}
       placeholder="Search Accounts"
     />
   );

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "eslint": "3.7.1",
     "lodash.debounce": "^4.0.8",
     "lodash.isstring": "^4.0.1",
     "lodash.omit": "^4.5.0",
@@ -65,7 +64,7 @@
     "copy-webpack-plugin": "^3.0.1",
     "css-loader": "^0.24.0",
     "enzyme": "^2.4.1",
-    "eslint": "^3.7.1",
+    "eslint": "3.7.1",
     "eslint-config-airbnb": "^12.0.0",
     "eslint-import-resolver-webpack": "^0.6.0",
     "eslint-plugin-import": "^1.16.0",

--- a/src/components/Lookup/__tests__/Lookup.spec.js
+++ b/src/components/Lookup/__tests__/Lookup.spec.js
@@ -253,4 +253,19 @@ describe('<Lookup />', () => {
     expect(mounted.find('.slds-lookup').hasClass('foo')).toBeTruthy();
     expect(mounted.find('.slds-lookup').prop('data-test')).toEqual('bar');
   });
+
+  it('calls a function when a result is added and replaces the result-pill if a component is returned', () => {
+    const mockFn = jest.fn(() => <div key="replaced">Replace me</div>);
+    mounted.setProps({ onResultAdd: mockFn });
+    mounted.setState({ open: true, loaded: sampleData, selected: [] });
+
+    mounted.find('.slds-lookup__list li > span').first().simulate('click');
+
+    expect(mockFn).toBeCalled();
+
+    const mockCall = mockFn.mock.calls[0];
+
+    expect(React.isValidElement(mockCall[0])).toBeTruthy();
+    expect(mockCall[1].id).toEqual('1');
+  });
 });


### PR DESCRIPTION
 Adds a callback that is executed when a result is added in `Lookup`.

The callback is passed the result pill and according item from the state and applies a cloned node if the callback returns one.

This is needed for PHOENIX-447 and I do not see another way to implement this besides completely rewriting the component to be more modular (something we should probably do anyways sooner or later)

@wwwdata I'd like to have your input on whether this is too much of a hack when you are back to health.

Also done in this PR:

 - Cleaned up callbacks in Lookup, removed all binds in `render`
 - Shortened the debounce delay in `Lookup` to 400ms
 - Removed a duplicate dependency for eslint.