### PR TITLE
Enable opt-out from cell truncation

### DIFF
--- a/src/components/DataTable/Cell.js
+++ b/src/components/DataTable/Cell.js
@@ -16,6 +16,7 @@ export const Cell = (props, { cssPrefix }) => {
     sortDirection,
     sortAssistiveText,
     title,
+    truncate,
     ...rest,
   } = props;
   const prefix = (classes, passThrough) => prefixClasses(cssPrefix, classes, passThrough);
@@ -115,6 +116,7 @@ export const Cell = (props, { cssPrefix }) => {
   childArray.push(assistiveText(4));
 
   const wrappedChildren = wrapChildren(childArray);
+  const wrapperClassName = truncate ? prefix('truncate') : null;
 
   return (
     <CellElement
@@ -123,7 +125,7 @@ export const Cell = (props, { cssPrefix }) => {
       scope={cellScope}
       title={cellTitle}
     >
-      <div className={prefix('truncate')}>
+      <div className={wrapperClassName}>
         {wrappedChildren}
       </div>
     </CellElement>
@@ -139,6 +141,7 @@ Cell.defaultProps = {
   resizableAssistiveText: 'Resize Cell',
   sortAssistiveText: 'Sort Column',
   sortDirection: 'asc',
+  truncate: true,
 };
 
 Cell.contextTypes = { cssPrefix: PropTypes.string };
@@ -180,6 +183,10 @@ Cell.propTypes = {
    * overrides the cell's title attribute
    */
   title: PropTypes.string,
+  /**
+   * Whether the cell content should be truncated
+   */
+  truncate: PropTypes.bool,
 };
 
 export default variationable(Cell);

--- a/src/components/DataTable/__tests__/Cell.spec.js
+++ b/src/components/DataTable/__tests__/Cell.spec.js
@@ -64,4 +64,13 @@ describe('<Cell />', () => {
     expect(mounted.find('td').hasClass('foo')).toBeTruthy();
     expect(mounted.find('td').prop('data-test')).toEqual('bar');
   });
+
+  it('truncates the cell content by default', () => {
+    expect(mounted.find('.slds-truncate').length).toBe(1);
+  });
+
+  it('won\'t truncate if truncate prop is set to false', () => {
+    mounted.setProps({ truncate: false });
+    expect(mounted.find('.slds-truncate').length).toBe(0);
+  });
 });


### PR DESCRIPTION
Trunaction opt-out is required for absolute elements within cells (e.g. Lookup components)