### PR TITLE
Add opt-in support for controlled lookup selection

### DIFF
--- a/docs/src/app/pages/Lookups/ExampleControlled.js
+++ b/docs/src/app/pages/Lookups/ExampleControlled.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Button, Lookup } from 'react-lds';
+
+const exampleData = [
+  {
+    id: '1',
+    label: 'Something',
+    meta: 'Very meta',
+    objectType: 'contact',
+  },
+  {
+    id: '2',
+    label: 'Really',
+    objectType: 'contact',
+  },
+  {
+    id: '3',
+    label: 'Not so',
+    objectType: 'contact',
+  },
+  {
+    id: '4',
+    label: 'Much useful',
+    objectType: 'contact',
+  },
+  {
+    id: '5',
+    label: 'Of any type',
+    objectType: 'contact',
+  },
+  {
+    id: '6',
+    label: 'Of some type',
+    objectType: 'account',
+  },
+  {
+    id: '7',
+    label: 'Of some record type',
+    objectType: 'record',
+  },
+];
+
+class ExampleControlled extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selection: [],
+    };
+  }
+  onResetClick = () => {
+    this.setState({ selection: [] });
+  }
+
+  onChange = (selection) => {
+    this.setState({ selection });
+  }
+
+  loadFunction = () => {
+    // eslint-disable-next-line no-console
+    console.log('load called');
+    return exampleData;
+  }
+
+  render() {
+    const { selection } = this.state;
+
+    return (
+      <div>
+        <Lookup
+          id="lookup"
+          inputLabel="Accounts"
+          listLabel="Recent Accounts"
+          load={this.loadFunction}
+          placeholder="Search Accounts"
+          onChange={this.onChange}
+          selection={selection}
+        />
+        <Button onClick={this.onResetClick}>
+          Reset selection
+        </Button>
+      </div>
+    );
+  }
+}
+
+export default ExampleControlled;

--- a/docs/src/app/pages/Lookups/index.js
+++ b/docs/src/app/pages/Lookups/index.js
@@ -4,6 +4,7 @@ import exampleDefaultCode from '!raw!./ExampleDefault';
 import exampleMultiCode from '!raw!./ExampleMulti';
 import exampleMultiCreateCode from '!raw!./ExampleMultiCreate';
 import exampleMultiTableCode from '!raw!./ExampleMultiTable';
+import exampleControlledCode from '!raw!./ExampleControlled';
 import lookupCode from '!raw!react-lds/components/Lookup/Lookup';
 
 import CodeExample from '../../components/CodeExample';
@@ -15,6 +16,7 @@ import ExampleDefault from './ExampleDefault';
 import ExampleMulti from './ExampleMulti';
 import ExampleMultiCreate from './ExampleMultiCreate';
 import ExampleMultiTable from './ExampleMultiTable';
+import ExampleControlled from './ExampleControlled';
 
 const LookupPage = () => (
   <div>
@@ -48,6 +50,14 @@ const LookupPage = () => (
         code={exampleMultiTableCode}
       />
       <ExampleMultiTable />
+    </div>
+
+    <div className="slds-p-around--xx-large">
+      <CodeExample
+        title="Controlled Lookup"
+        code={exampleControlledCode}
+      />
+      <ExampleControlled />
     </div>
 
     <PropTypeDescription code={lookupCode} />

--- a/src/components/Lookup/Lookup.js
+++ b/src/components/Lookup/Lookup.js
@@ -66,6 +66,10 @@ export class Lookup extends React.Component {
      */
     initialSelection: validateSelection,
     /**
+     * item selection
+     */
+    selection: validateSelection,
+    /**
      * label for the input field in the lookup component
      */
     inputLabel: PropTypes.string.isRequired,
@@ -130,6 +134,7 @@ export class Lookup extends React.Component {
 
   static defaultProps = {
     initialSelection: [],
+    selection: [],
     loadOnChange: true,
     multi: false,
     placeholder: 'Search',
@@ -139,13 +144,15 @@ export class Lookup extends React.Component {
   constructor(props, context) {
     super(props, context);
 
+    const { initialSelection, selection } = props;
+
     this.prefix = (classes, passThrough) => prefixClasses(this.context.cssPrefix, classes, passThrough);
     this.state = {
       searchTerm: '',
       highlighted: null,
       open: false,
       loaded: [],
-      selected: this.props.initialSelection,
+      selected: initialSelection || selection || [],
     };
 
     this.handleLoad = debounce(this.handleLoad, 500);
@@ -155,6 +162,15 @@ export class Lookup extends React.Component {
   componentDidMount() {
     if (this.props.loadOnMount) {
       this.handleLoad();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { selection } = this.state;
+    const { selection: nextSelection } = nextProps;
+
+    if (selection !== nextSelection) {
+      this.setState({ selected: nextSelection });
     }
   }
 

--- a/src/components/Lookup/Lookup.js
+++ b/src/components/Lookup/Lookup.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import enhanceWithClickOutside from 'react-click-outside';
 import debounce from 'lodash.debounce';
 import omit from 'lodash.omit';
+import has from 'lodash/has';
 
 import { prefixClasses } from '../../utils';
 import {
@@ -166,11 +167,17 @@ export class Lookup extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    const { load } = this.props;
     const { selection } = this.state;
-    const { selection: nextSelection } = nextProps;
 
-    if (selection !== nextSelection) {
+    const { load: nextLoad, selection: nextSelection } = nextProps;
+
+    if (has(nextProps, 'selection') && selection !== nextSelection) {
       this.setState({ selected: nextSelection });
+    }
+
+    if (load && load !== nextLoad) {
+      this.setState({ selected: [] });
     }
   }
 

--- a/src/components/Lookup/__tests__/Lookup.spec.js
+++ b/src/components/Lookup/__tests__/Lookup.spec.js
@@ -255,6 +255,14 @@ describe('<Lookup />', () => {
     expect(mounted.find('.slds-lookup').prop('data-test')).toEqual('bar');
   });
 
+  it('clears the internal state when the load function changes', () => {
+    const load = () => {};
+    const newLoad = () => {};
+    mounted.setProps({ load, selection: [sampleData[0]] });
+    mounted.setProps({ load: newLoad });
+    expect(mounted.state().selected).toEqual([]);
+  });
+
   describe('with controlled selection', () => {
     beforeEach(() => {
       mounted.setProps({ selection: [sampleData[0]] });

--- a/src/components/Lookup/__tests__/Lookup.spec.js
+++ b/src/components/Lookup/__tests__/Lookup.spec.js
@@ -254,4 +254,25 @@ describe('<Lookup />', () => {
     expect(mounted.find('.slds-lookup').hasClass('foo')).toBeTruthy();
     expect(mounted.find('.slds-lookup').prop('data-test')).toEqual('bar');
   });
+
+  describe('with controlled selection', () => {
+    beforeEach(() => {
+      mounted.setProps({ selection: [sampleData[0]] });
+    });
+
+    it('takes the selection from the selection prop', () => {
+      expect(mounted.state().selected).toEqual([sampleData[0]]);
+    });
+
+    it('updates the selection when the selection prop changes', () => {
+      mounted.setProps({ selection: [sampleData[1]] });
+      expect(mounted.state().selected).toEqual([sampleData[1]]);
+    });
+
+    it('does not call onChange', () => {
+      const onChange = jest.fn();
+      mounted.setProps({ onChange, selection: [sampleData[1]] });
+      expect(onChange).not.toBeCalled();
+    });
+  });
 });


### PR DESCRIPTION
This is required to be able to control the lookup selection from outside. It is optional and should not interfere with existing usages of the lookup component.