### PR TITLE
Multiple updates or fixes datepicker

### DIFF
--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -361,7 +361,7 @@ export class Datepicker extends React.Component {
     };
 
     return (
-      <td key={dayIndex} className={cx(classes)} headers={day.day()}>
+      <td key={dayIndex} className={cx(classes)}>
         <span className="slds-day" onClick={onClick}>
           {day.date()}
         </span>

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -357,14 +357,23 @@ export class Datepicker extends React.Component {
 
     const isToday = day.isSame(moment(), 'day');
 
+    const isSelected = day.isSame(moment(inputValue, defaultDateFormat), 'day');
+
     const classes = {
       'slds-is-today': day.isSame(moment(), 'day'),
       'slds-disabled-text': !inRange,
-      'slds-is-selected': day.isSame(moment(inputValue, defaultDateFormat), 'day'),
+      'slds-is-selected': isSelected,
     };
 
     return (
-      <td key={dayIndex} className={cx(classes)}>
+      <td
+        aria-disabled={!inRange ? 'true' : null}
+        aria-selected={isSelected}
+        className={cx(classes)}
+        key={dayIndex}
+        role="gridcell"
+        tabIndex={inRange ? '0' : null}
+      >
         <span className="slds-day" onClick={onClick}>
           {isToday && <span className="slds-assistive-text">Today: </span>}
           {day.date()}

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -372,6 +372,7 @@ export class Datepicker extends React.Component {
   render() {
     const { required } = this.props;
     const { inputValue, isValid, open, viewedDate } = this.state;
+    const viewedMonthName = moment(viewedDate).format('MMMM');
 
     const inputFieldLabel = this.getTranslations('inputFieldLabel');
     const inputFieldError = this.getTranslations('inputFieldError');
@@ -392,7 +393,11 @@ export class Datepicker extends React.Component {
           required={required}
         />
         {open && (
-          <div className="slds-datepicker slds-dropdown slds-dropdown_left">
+          <div
+            aria-label={`Date picker: ${viewedMonthName}`}
+            className="slds-datepicker slds-dropdown slds-dropdown_left"
+            role="dialog"
+          >
             <div className="slds-datepicker__filter slds-grid">
               <div className="slds-datepicker__filter_month slds-grid slds-grid_align-spread slds-grow">
                 <div className="slds-align-middle">
@@ -411,7 +416,11 @@ export class Datepicker extends React.Component {
               </div>
               {this.renderYearPicker()}
             </div>
-            <table className="slds-datepicker__month" role="grid">
+            <table
+              aria-multiselectable={inputValue !== '' ? true : null}
+              className="slds-datepicker__month"
+              role="grid"
+            >
               {Datepicker.renderWeekHeader()}
               {this.renderMonth()}
             </table>

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -62,6 +62,7 @@ export class Datepicker extends React.Component {
       ${moment().localeData().longDateFormat(placeholderDateFormat)}`;
 
     if (date && initialDate) {
+      // eslint-disable-next-line no-console
       console.warn(
         '[react-lds] Datepicker:',
         'You are supplying both `initialDate` & `date`, ignoring `initialDate`.',
@@ -420,7 +421,6 @@ export class Datepicker extends React.Component {
               {this.renderYearPicker()}
             </div>
             <table
-              aria-multiselectable={inputValue !== '' ? true : null}
               className="slds-datepicker__month"
               role="grid"
             >

--- a/src/components/Datepicker/Datepicker.js
+++ b/src/components/Datepicker/Datepicker.js
@@ -354,6 +354,8 @@ export class Datepicker extends React.Component {
 
     const onClick = () => inRange && this.onDatepickerChange(day);
 
+    const isToday = day.isSame(moment(), 'day');
+
     const classes = {
       'slds-is-today': day.isSame(moment(), 'day'),
       'slds-disabled-text': !inRange,
@@ -363,6 +365,7 @@ export class Datepicker extends React.Component {
     return (
       <td key={dayIndex} className={cx(classes)}>
         <span className="slds-day" onClick={onClick}>
+          {isToday && <span className="slds-assistive-text">Today: </span>}
           {day.date()}
         </span>
       </td>

--- a/src/components/Datepicker/__tests__/Datepicker.spec.js
+++ b/src/components/Datepicker/__tests__/Datepicker.spec.js
@@ -26,7 +26,7 @@ describe('<Datepicker />', () => {
   });
 
   it('highlights the current day', () => {
-    expect(mounted.find('.slds-is-today').children().first().text()).toBe(moment().format('D'));
+    expect(mounted.find('.slds-is-today').children().first().text()).toBe(`Today: ${moment().format('D')}`);
   });
 
   it('allows the user to select the next month', () => {


### PR DESCRIPTION
Issue #136 Datepicker-stuff:

> Date Picker: Added role="dialog" to the slds-datepicker
> Date Picker: Added aria-label to the dialog to describe its purpose
> Date Picker: Removed headers attribute from each gridcell
> Date Picker: Added assistive text for when we mark today's date in the grid. We do this to provide additional meaning since the grey background color is not enough of an indicator to non-sighted users
 Date Picker: Changed the "Today" option to be a selectable cell, just like any other day in the grid, by removing its tag
> Date Picker: Made the first day cell focusable as it is a ARIA grid widget

Did not implement the following because AFAIK our Datepicker doesn't support mulitple date input.
> Date Picker: Added aria-multiselectable="true" to the grid to indicate you can selected multiple dates