### PR TITLE
Add option for disabling error message display

### DIFF
--- a/docs/src/app/pages/Form/Checkbox/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Checkbox/ExampleErrorMessage.js
@@ -8,7 +8,7 @@ const ExampleErrorMessage = () =>
       id="checkbox-input-1"
       label="Checkbox Label"
       error="Something is wrong"
-      errorMessage={false}
+      hideErrorMessage
       required
     />
   </div>;

--- a/docs/src/app/pages/Form/Checkbox/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Checkbox/ExampleErrorMessage.js
@@ -2,14 +2,15 @@ import React from 'react';
 
 import { Checkbox } from 'react-lds';
 
-const ExampleError = () =>
+const ExampleErrorMessage = () =>
   <div>
     <Checkbox
       id="checkbox-input-1"
       label="Checkbox Label"
       error="Something is wrong"
+      errorMessage={false}
       required
     />
   </div>;
 
-export default ExampleError;
+export default ExampleErrorMessage;

--- a/docs/src/app/pages/Form/Checkbox/ExampleGroupErrorMessage.js
+++ b/docs/src/app/pages/Form/Checkbox/ExampleGroupErrorMessage.js
@@ -4,7 +4,7 @@ import { CheckboxGroup, CheckboxRaw } from 'react-lds';
 
 const ExampleGroupErrorMessage = () =>
   <div>
-    <CheckboxGroup id="fieldset-1" label="Fieldset" error="Oops, an error" errorMessage={false}>
+    <CheckboxGroup id="fieldset-1" label="Fieldset" error="Oops, an error" hideErrorMessage>
       <CheckboxRaw
         id="checkbox-input-1"
         label="Checkbox Label"

--- a/docs/src/app/pages/Form/Checkbox/ExampleGroupErrorMessage.js
+++ b/docs/src/app/pages/Form/Checkbox/ExampleGroupErrorMessage.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { CheckboxGroup, CheckboxRaw } from 'react-lds';
+
+const ExampleGroupErrorMessage = () =>
+  <div>
+    <CheckboxGroup id="fieldset-1" label="Fieldset" error="Oops, an error" errorMessage={false}>
+      <CheckboxRaw
+        id="checkbox-input-1"
+        label="Checkbox Label"
+      />
+      <CheckboxRaw
+        id="checkbox-input-2"
+        label="Checkbox Label"
+      />
+      <CheckboxRaw
+        id="checkbox-input-3"
+        label="Checkbox Label"
+      />
+      <CheckboxRaw
+        id="checkbox-input-4"
+        label="Checkbox Label"
+      />
+    </CheckboxGroup>
+  </div>;
+
+export default ExampleGroupErrorMessage;

--- a/docs/src/app/pages/Form/Checkbox/index.js
+++ b/docs/src/app/pages/Form/Checkbox/index.js
@@ -4,9 +4,11 @@ import PropTypes from 'prop-types';
 import exampleDefaultCode from '!raw!./ExampleDefault';
 import exampleDisabledCode from '!raw!./ExampleDisabled';
 import exampleErrorCode from '!raw!./ExampleError';
+import exampleErrorMessageCode from '!raw!./ExampleErrorMessage';
 import exampleGroupCode from '!raw!./ExampleGroup';
 import exampleGroupDisabledCode from '!raw!./ExampleGroupDisabled';
 import exampleGroupErrorCode from '!raw!./ExampleGroupError';
+import exampleGroupErrorMessageCode from '!raw!./ExampleGroupErrorMessage';
 import exampleGroupRequiredCode from '!raw!./ExampleGroupRequired';
 import exampleRequiredCode from '!raw!./ExampleRequired';
 import inputCode from '!raw!react-lds/components/Form/Input';
@@ -17,9 +19,11 @@ import PropTypeDescription from '../../../components/PropTypeDescription';
 import ExampleDefault from './ExampleDefault';
 import ExampleDisabled from './ExampleDisabled';
 import ExampleError from './ExampleError';
+import ExampleErrorMessage from './ExampleErrorMessage';
 import ExampleGroup from './ExampleGroup';
 import ExampleGroupDisabled from './ExampleGroupDisabled';
 import ExampleGroupError from './ExampleGroupError';
+import ExampleGroupErrorMessage from './ExampleGroupErrorMessage';
 import ExampleGroupRequired from './ExampleGroupRequired';
 import ExampleRequired from './ExampleRequired';
 
@@ -44,19 +48,27 @@ const mapId = (id) => {
       Component = ExampleError;
       componentCode = exampleErrorCode;
       break;
+    case 'error-message':
+      Component = ExampleErrorMessage;
+      componentCode = exampleErrorMessageCode;
+      break;
     case 'group':
       Component = ExampleGroup;
       componentCode = exampleGroupCode;
       break;
-    case 'group_disabled':
+    case 'group-disabled':
       Component = ExampleGroupDisabled;
       componentCode = exampleGroupDisabledCode;
       break;
-    case 'group_error':
+    case 'group-error':
       Component = ExampleGroupError;
       componentCode = exampleGroupErrorCode;
       break;
-    case 'group_required':
+    case 'group-error-message':
+      Component = ExampleGroupErrorMessage;
+      componentCode = exampleGroupErrorMessageCode;
+      break;
+    case 'group-required':
       Component = ExampleGroupRequired;
       componentCode = exampleGroupRequiredCode;
       break;

--- a/docs/src/app/pages/Form/Input/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Input/ExampleErrorMessage.js
@@ -4,7 +4,7 @@ import { Input } from 'react-lds';
 
 const ExampleErrorMessage = () =>
   <div>
-    <Input required id="input-9" label="This could go wrong" error="This field must be purple!" errorMessage={false} />
+    <Input required id="input-9" label="This could go wrong" error="This field must be purple!" hideErrorMessage />
   </div>;
 
 export default ExampleErrorMessage;

--- a/docs/src/app/pages/Form/Input/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Input/ExampleErrorMessage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Input } from 'react-lds';
+
+const ExampleErrorMessage = () =>
+  <div>
+    <Input required id="input-9" label="This could go wrong" error="This field must be purple!" errorMessage={false} />
+  </div>;
+
+export default ExampleErrorMessage;

--- a/docs/src/app/pages/Form/Input/index.js
+++ b/docs/src/app/pages/Form/Input/index.js
@@ -5,6 +5,7 @@ import exampleDefaultCode from '!raw!./ExampleDefault';
 import exampleDisabledCode from '!raw!./ExampleDisabled';
 import exampleErrorCode from '!raw!./ExampleError';
 import exampleErrorIconCode from '!raw!./ExampleErrorIcon';
+import exampleErrorMessageCode from '!raw!./ExampleErrorMessage';
 import exampleIconLeftCode from '!raw!./ExampleIconLeft';
 import exampleIconLeftRightCode from '!raw!./ExampleIconLeftRight';
 import exampleIconRightCode from '!raw!./ExampleIconRight';
@@ -20,6 +21,7 @@ import ExampleDefault from './ExampleDefault';
 import ExampleDisabled from './ExampleDisabled';
 import ExampleError from './ExampleError';
 import ExampleErrorIcon from './ExampleErrorIcon';
+import ExampleErrorMessage from './ExampleErrorMessage';
 import ExampleIconLeft from './ExampleIconLeft';
 import ExampleIconLeftRight from './ExampleIconLeftRight';
 import ExampleIconRight from './ExampleIconRight';
@@ -71,6 +73,10 @@ const mapId = (id) => {
     case 'error-icon':
       Component = ExampleErrorIcon;
       componentCode = exampleErrorIconCode;
+      break;
+    case 'error-message':
+      Component = ExampleErrorMessage;
+      componentCode = exampleErrorMessageCode;
       break;
     default:
       break;

--- a/docs/src/app/pages/Form/Select/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Select/ExampleErrorMessage.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Select } from 'react-lds';
+
+const ExampleErrorMessage = () =>
+  <div>
+    <Select id="select-1" label="Select Label" error="This field is required" errorMessage={false} required>
+      <option>Option One</option>
+      <option>Option Two</option>
+      <option>Option Three</option>
+    </Select>
+  </div>;
+
+export default ExampleErrorMessage;

--- a/docs/src/app/pages/Form/Select/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Select/ExampleErrorMessage.js
@@ -4,7 +4,7 @@ import { Select } from 'react-lds';
 
 const ExampleErrorMessage = () =>
   <div>
-    <Select id="select-1" label="Select Label" error="This field is required" errorMessage={false} required>
+    <Select id="select-1" label="Select Label" error="This field is required" hideErrorMessage required>
       <option>Option One</option>
       <option>Option Two</option>
       <option>Option Three</option>

--- a/docs/src/app/pages/Form/Select/index.js
+++ b/docs/src/app/pages/Form/Select/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import exampleDefaultCode from '!raw!./ExampleDefault';
 import exampleDisabledCode from '!raw!./ExampleDisabled';
 import exampleErrorCode from '!raw!./ExampleError';
+import exampleErrorMessageCode from '!raw!./ExampleErrorMessage';
 import exampleMultipleCode from '!raw!./ExampleMultiple';
 import exampleRequiredCode from '!raw!./ExampleRequired';
 import selectCode from '!raw!react-lds/components/Form/Select';
@@ -14,6 +15,7 @@ import PropTypeDescription from '../../../components/PropTypeDescription';
 import ExampleDefault from './ExampleDefault';
 import ExampleDisabled from './ExampleDisabled';
 import ExampleError from './ExampleError';
+import ExampleErrorMessage from './ExampleErrorMessage';
 import ExampleMultiple from './ExampleMultiple';
 import ExampleRequired from './ExampleRequired';
 
@@ -33,6 +35,10 @@ const mapId = (id) => {
     case 'error':
       Component = ExampleError;
       componentCode = exampleErrorCode;
+      break;
+    case 'error-message':
+      Component = ExampleErrorMessage;
+      componentCode = exampleErrorMessageCode;
       break;
     case 'disabled':
       Component = ExampleDisabled;

--- a/docs/src/app/pages/Form/Textarea/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Textarea/ExampleErrorMessage.js
@@ -9,7 +9,7 @@ const ExampleErrorMessage = () =>
       label="Textarea Label"
       placeholder="Placeholder Text"
       error="This field is required"
-      errorMessage={false}
+      hideErrorMessage
       required
     />
   </div>;

--- a/docs/src/app/pages/Form/Textarea/ExampleErrorMessage.js
+++ b/docs/src/app/pages/Form/Textarea/ExampleErrorMessage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { Textarea } from 'react-lds';
+
+const ExampleErrorMessage = () =>
+  <div>
+    <Textarea
+      id="textarea-input-1"
+      label="Textarea Label"
+      placeholder="Placeholder Text"
+      error="This field is required"
+      errorMessage={false}
+      required
+    />
+  </div>;
+
+export default ExampleErrorMessage;

--- a/docs/src/app/pages/Form/Textarea/index.js
+++ b/docs/src/app/pages/Form/Textarea/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import exampleDefaultCode from '!raw!./ExampleDefault';
 import exampleDisabledCode from '!raw!./ExampleDisabled';
 import exampleErrorCode from '!raw!./ExampleError';
+import exampleErrorMessageCode from '!raw!./ExampleErrorMessage';
 import exampleReadonlyCode from '!raw!./ExampleReadonly';
 import exampleRequiredCode from '!raw!./ExampleRequired';
 import inputCode from '!raw!react-lds/components/Form/Textarea';
@@ -14,6 +15,7 @@ import PropTypeDescription from '../../../components/PropTypeDescription';
 import ExampleDefault from './ExampleDefault';
 import ExampleDisabled from './ExampleDisabled';
 import ExampleError from './ExampleError';
+import ExampleErrorMessage from './ExampleErrorMessage';
 import ExampleReadonly from './ExampleReadonly';
 import ExampleRequired from './ExampleRequired';
 
@@ -33,6 +35,10 @@ const mapId = (id) => {
     case 'error':
       Component = ExampleError;
       componentCode = exampleErrorCode;
+      break;
+    case 'error-message':
+      Component = ExampleErrorMessage;
+      componentCode = exampleErrorMessageCode;
       break;
     case 'disabled':
       Component = ExampleDisabled;

--- a/docs/src/app/pages/Form/index.js
+++ b/docs/src/app/pages/Form/index.js
@@ -31,12 +31,14 @@ const Forms = ({ children }) =>
             <PageNavigationElement to="/forms/input/required">Required</PageNavigationElement>
             <PageNavigationElement to="/forms/input/disabled">Disabled</PageNavigationElement>
             <PageNavigationElement to="/forms/input/error">Error</PageNavigationElement>
-            <PageNavigationElement to="forms/input/error-icon">Error with icon</PageNavigationElement>
+            <PageNavigationElement to="forms/input/error-icon">Error with Icon</PageNavigationElement>
+            <PageNavigationElement to="forms/input/error-message">Error without Message</PageNavigationElement>
           </PageNavigationMenu>
           <PageNavigationMenu title="Textarea" to="/forms/textarea">
             <PageNavigationElement to="/forms/textarea/default">Default</PageNavigationElement>
             <PageNavigationElement to="/forms/textarea/required">Required</PageNavigationElement>
             <PageNavigationElement to="/forms/textarea/error">Error</PageNavigationElement>
+            <PageNavigationElement to="/forms/textarea/error-message">Error without Message</PageNavigationElement>
             <PageNavigationElement to="/forms/textarea/disabled">Disabled</PageNavigationElement>
             <PageNavigationElement to="/forms/textarea/readonly">Read-Only</PageNavigationElement>
           </PageNavigationMenu>
@@ -45,6 +47,7 @@ const Forms = ({ children }) =>
             <PageNavigationElement to="/forms/select/default">Default</PageNavigationElement>
             <PageNavigationElement to="/forms/select/required">Required</PageNavigationElement>
             <PageNavigationElement to="/forms/select/error">Error</PageNavigationElement>
+            <PageNavigationElement to="/forms/select/error-message">Error without Message</PageNavigationElement>
             <PageNavigationElement to="/forms/select/disabled">Disabled</PageNavigationElement>
             <PageNavigationElement to="/forms/select/multiple">Multiple Selection</PageNavigationElement>
           </PageNavigationMenu>
@@ -55,10 +58,14 @@ const Forms = ({ children }) =>
             <PageNavigationElement to="/forms/checkbox/default">Default</PageNavigationElement>
             <PageNavigationElement to="/forms/checkbox/required">Required</PageNavigationElement>
             <PageNavigationElement to="/forms/checkbox/error">Error</PageNavigationElement>
+            <PageNavigationElement to="/forms/checkbox/error-message">Error without Message</PageNavigationElement>
             <PageNavigationElement to="/forms/checkbox/disabled">Disabled</PageNavigationElement>
             <PageNavigationElement to="/forms/checkbox/group">Group</PageNavigationElement>
-            <PageNavigationElement to="/forms/checkbox/group_error">Group with Error</PageNavigationElement>
-            <PageNavigationElement to="/forms/checkbox/group_disabled">Group Disabled</PageNavigationElement>
+            <PageNavigationElement to="/forms/checkbox/group-error">Group with Error</PageNavigationElement>
+            <PageNavigationElement to="/forms/checkbox/group-error-message">
+              Group with Error without Message
+            </PageNavigationElement>
+            <PageNavigationElement to="/forms/checkbox/group-disabled">Group Disabled</PageNavigationElement>
           </PageNavigationMenu>
         </PageNavigation>
       </Column>

--- a/src/components/Form/Checkbox.js
+++ b/src/components/Form/Checkbox.js
@@ -11,7 +11,7 @@ import {
 const Checkbox = (props) => {
   const {
     error,
-    errorMessage,
+    hideErrorMessage,
     id,
     required,
   } = props;
@@ -21,14 +21,14 @@ const Checkbox = (props) => {
       <FormElementControl>
         <CheckboxRaw {...props} />
       </FormElementControl>
-      {errorMessage && <FormElementError error={error} id={id} />}
+      {!hideErrorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
 
 Checkbox.defaultProps = {
   error: null,
-  errorMessage: true,
+  hideErrorMessage: false,
   hideLabel: false,
   required: false,
 };
@@ -39,9 +39,9 @@ Checkbox.propTypes = {
    */
   error: PropTypes.string,
   /**
-   * renders the error message
+   * hides the error message
    */
-  errorMessage: PropTypes.bool,
+  hideErrorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/Checkbox.js
+++ b/src/components/Form/Checkbox.js
@@ -11,6 +11,7 @@ import {
 const Checkbox = (props) => {
   const {
     error,
+    errorMessage,
     id,
     required,
   } = props;
@@ -20,13 +21,14 @@ const Checkbox = (props) => {
       <FormElementControl>
         <CheckboxRaw {...props} />
       </FormElementControl>
-      <FormElementError error={error} id={id} />
+      {errorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
 
 Checkbox.defaultProps = {
   error: null,
+  errorMessage: true,
   hideLabel: false,
   required: false,
 };
@@ -36,6 +38,10 @@ Checkbox.propTypes = {
   * renders an error for the checkbox
    */
   error: PropTypes.string,
+  /**
+   * renders the error message
+   */
+  errorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/CheckboxGroup.js
+++ b/src/components/Form/CheckboxGroup.js
@@ -15,7 +15,7 @@ const CheckboxGroup = (props) => {
     children,
     className,
     error,
-    errorMessage,
+    hideErrorMessage,
     id,
     label,
     onChange,
@@ -25,7 +25,7 @@ const CheckboxGroup = (props) => {
 
 
   const wrapChildrenWithError = () => {
-    if (!error || !errorMessage) {
+    if (!error || hideErrorMessage) {
       return children;
     }
 
@@ -48,7 +48,7 @@ const CheckboxGroup = (props) => {
       <FormElementControl>
         {wrapChildrenWithError()}
       </FormElementControl>
-      {errorMessage && <FormElementError error={error} id={id} />}
+      {!hideErrorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -56,7 +56,7 @@ const CheckboxGroup = (props) => {
 CheckboxGroup.defaultProps = {
   className: null,
   error: null,
-  errorMessage: true,
+  hideErrorMessage: false,
   onChange: () => {},
   required: false,
 };
@@ -75,9 +75,9 @@ CheckboxGroup.propTypes = {
    */
   error: PropTypes.string,
   /**
-   * renders the error message
+   * hides the error message
    */
-  errorMessage: PropTypes.bool,
+  hideErrorMessage: PropTypes.bool,
   /**
    * id of the fieldset
    */

--- a/src/components/Form/CheckboxGroup.js
+++ b/src/components/Form/CheckboxGroup.js
@@ -15,6 +15,7 @@ const CheckboxGroup = (props) => {
     children,
     className,
     error,
+    errorMessage,
     id,
     label,
     onChange,
@@ -24,7 +25,7 @@ const CheckboxGroup = (props) => {
 
 
   const wrapChildrenWithError = () => {
-    if (!error) {
+    if (!error || !errorMessage) {
       return children;
     }
 
@@ -47,7 +48,7 @@ const CheckboxGroup = (props) => {
       <FormElementControl>
         {wrapChildrenWithError()}
       </FormElementControl>
-      <FormElementError error={error} id={id} />
+      {errorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -55,6 +56,7 @@ const CheckboxGroup = (props) => {
 CheckboxGroup.defaultProps = {
   className: null,
   error: null,
+  errorMessage: true,
   onChange: () => {},
   required: false,
 };
@@ -72,6 +74,10 @@ CheckboxGroup.propTypes = {
    * renders an error for the fieldset
    */
   error: PropTypes.string,
+  /**
+   * renders the error message
+   */
+  errorMessage: PropTypes.bool,
   /**
    * id of the fieldset
    */

--- a/src/components/Form/CheckboxRaw.js
+++ b/src/components/Form/CheckboxRaw.js
@@ -10,6 +10,7 @@ const CheckboxRaw = (props) => {
     className,
     disabled,
     error,
+    errorMessage,
     hideLabel,
     id,
     label,
@@ -20,7 +21,7 @@ const CheckboxRaw = (props) => {
 
   const renderCheckbox = () => (
     <input
-      aria-describedby={error ? getUniqueHash(error, id) : null}
+      aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
       {...rest}
       checked={checked}
       className={className}
@@ -66,6 +67,7 @@ CheckboxRaw.defaultProps = {
   className: null,
   disabled: false,
   error: null,
+  errorMessage: true,
   hideLabel: false,
   onChange: () => {},
   required: false,
@@ -88,6 +90,10 @@ CheckboxRaw.propTypes = {
   * renders an error for the checkbox
    */
   error: PropTypes.string,
+  /**
+   * disables the error message
+   */
+  errorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/CheckboxRaw.js
+++ b/src/components/Form/CheckboxRaw.js
@@ -10,7 +10,7 @@ const CheckboxRaw = (props) => {
     className,
     disabled,
     error,
-    errorMessage,
+    hideErrorMessage,
     hideLabel,
     id,
     label,
@@ -21,7 +21,7 @@ const CheckboxRaw = (props) => {
 
   const renderCheckbox = () => (
     <input
-      aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
+      aria-describedby={error && !hideErrorMessage ? getUniqueHash(error, id) : null}
       {...rest}
       checked={checked}
       className={className}
@@ -67,7 +67,7 @@ CheckboxRaw.defaultProps = {
   className: null,
   disabled: false,
   error: null,
-  errorMessage: true,
+  hideErrorMessage: false,
   hideLabel: false,
   onChange: () => {},
   required: false,
@@ -91,9 +91,9 @@ CheckboxRaw.propTypes = {
    */
   error: PropTypes.string,
   /**
-   * disables the error message
+   * hides the error message
    */
-  errorMessage: PropTypes.bool,
+  hideErrorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -13,6 +13,7 @@ const Input = (props) => {
   const {
     error,
     errorIcon,
+    errorMessage,
     hideLabel,
     iconLeft,
     iconRight,
@@ -33,6 +34,7 @@ const Input = (props) => {
     <InputRaw
       error={error}
       errorIcon={errorIcon}
+      errorMessage={errorMessage}
       iconLeft={iconLeft}
       iconRight={iconRight}
       id={id}
@@ -60,7 +62,7 @@ const Input = (props) => {
       >
         {inputRaw}
       </FormElementControl>
-      <FormElementError error={error} id={id} />
+      {errorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -71,6 +73,7 @@ Input.defaultProps = {
   disabled: false,
   error: null,
   errorIcon: false,
+  errorMessage: true,
   hideLabel: false,
   iconLeft: null,
   iconRight: null,
@@ -103,13 +106,18 @@ Input.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
-   * renders an error for the input
+   * renders an error for the input. shows an error messsage if error is a string,
+   * just marks the input if its a boolean.
    */
   error: PropTypes.string,
   /**
    * renders an additional error icon if an error is set
    */
   errorIcon: PropTypes.bool,
+  /**
+   * renders the error message
+   */
+  errorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -13,7 +13,7 @@ const Input = (props) => {
   const {
     error,
     errorIcon,
-    errorMessage,
+    hideErrorMessage,
     hideLabel,
     iconLeft,
     iconRight,
@@ -34,7 +34,7 @@ const Input = (props) => {
     <InputRaw
       error={error}
       errorIcon={errorIcon}
-      errorMessage={errorMessage}
+      hideErrorMessage={hideErrorMessage}
       iconLeft={iconLeft}
       iconRight={iconRight}
       id={id}
@@ -62,7 +62,7 @@ const Input = (props) => {
       >
         {inputRaw}
       </FormElementControl>
-      {errorMessage && <FormElementError error={error} id={id} />}
+      {!hideErrorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -73,7 +73,7 @@ Input.defaultProps = {
   disabled: false,
   error: null,
   errorIcon: false,
-  errorMessage: true,
+  hideErrorMessage: false,
   hideLabel: false,
   iconLeft: null,
   iconRight: null,
@@ -115,9 +115,9 @@ Input.propTypes = {
    */
   errorIcon: PropTypes.bool,
   /**
-   * renders the error message
+   * hides the error message
    */
-  errorMessage: PropTypes.bool,
+  hideErrorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/InputRaw.js
+++ b/src/components/Form/InputRaw.js
@@ -17,7 +17,7 @@ const InputRaw = (props) => {
     disabled,
     error,
     errorIcon,
-    errorMessage,
+    hideErrorMessage,
     iconLeft,
     iconRight,
     iconRightOnClick,
@@ -119,7 +119,7 @@ const InputRaw = (props) => {
       {renderIconLeft()}
       <input
         {...rest}
-        aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
+        aria-describedby={error && !hideErrorMessage ? getUniqueHash(error, id) : null}
         className={cx(sldsClasses)}
         disabled={disabled}
         id={id}
@@ -147,7 +147,7 @@ InputRaw.defaultProps = {
   disabled: false,
   error: null,
   errorIcon: false,
-  errorMessage: true,
+  hideErrorMessage: false,
   iconLeft: null,
   iconRight: null,
   iconRightOnClick: () => {},
@@ -182,9 +182,9 @@ InputRaw.propTypes = {
    */
   error: PropTypes.string,
   /**
-   * disables the error message
+   * hides the error message
    */
-  errorMessage: PropTypes.bool,
+  hideErrorMessage: PropTypes.bool,
   /**
    * renders an additional error icon if an error is set
    */

--- a/src/components/Form/InputRaw.js
+++ b/src/components/Form/InputRaw.js
@@ -17,6 +17,7 @@ const InputRaw = (props) => {
     disabled,
     error,
     errorIcon,
+    errorMessage,
     iconLeft,
     iconRight,
     iconRightOnClick,
@@ -118,7 +119,7 @@ const InputRaw = (props) => {
       {renderIconLeft()}
       <input
         {...rest}
-        aria-describedby={error ? getUniqueHash(error, id) : null}
+        aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
         className={cx(sldsClasses)}
         disabled={disabled}
         id={id}
@@ -146,6 +147,7 @@ InputRaw.defaultProps = {
   disabled: false,
   error: null,
   errorIcon: false,
+  errorMessage: true,
   iconLeft: null,
   iconRight: null,
   iconRightOnClick: () => {},
@@ -179,6 +181,10 @@ InputRaw.propTypes = {
    * renders an error for the input
    */
   error: PropTypes.string,
+  /**
+   * disables the error message
+   */
+  errorMessage: PropTypes.bool,
   /**
    * renders an additional error icon if an error is set
    */

--- a/src/components/Form/Select.js
+++ b/src/components/Form/Select.js
@@ -16,7 +16,7 @@ const Select = (props) => {
     className,
     disabled,
     error,
-    errorMessage,
+    hideErrorMessage,
     hideLabel,
     id,
     label,
@@ -41,7 +41,7 @@ const Select = (props) => {
         multiple={multiple}
         required={required}
         disabled={disabled}
-        aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
+        aria-describedby={error && !hideErrorMessage ? getUniqueHash(error, id) : null}
       >
         {children}
       </select>
@@ -60,7 +60,7 @@ const Select = (props) => {
       <FormElementControl>
         {renderSelect()}
       </FormElementControl>
-      {errorMessage && <FormElementError error={error} id={id} />}
+      {!hideErrorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -69,7 +69,7 @@ Select.defaultProps = {
   className: null,
   disabled: false,
   error: null,
-  errorMessage: true,
+  hideErrorMessage: false,
   hideLabel: false,
   multiple: false,
   onChange: () => {},
@@ -94,9 +94,9 @@ Select.propTypes = {
    */
   error: PropTypes.string,
   /**
-   * renders the error message
+   * hides the error message
    */
-  errorMessage: PropTypes.bool,
+  hideErrorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/Select.js
+++ b/src/components/Form/Select.js
@@ -16,6 +16,7 @@ const Select = (props) => {
     className,
     disabled,
     error,
+    errorMessage,
     hideLabel,
     id,
     label,
@@ -40,7 +41,7 @@ const Select = (props) => {
         multiple={multiple}
         required={required}
         disabled={disabled}
-        aria-describedby={error ? getUniqueHash(error, id) : null}
+        aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
       >
         {children}
       </select>
@@ -59,7 +60,7 @@ const Select = (props) => {
       <FormElementControl>
         {renderSelect()}
       </FormElementControl>
-      <FormElementError error={error} id={id} />
+      {errorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -68,6 +69,7 @@ Select.defaultProps = {
   className: null,
   disabled: false,
   error: null,
+  errorMessage: true,
   hideLabel: false,
   multiple: false,
   onChange: () => {},
@@ -91,6 +93,10 @@ Select.propTypes = {
   * renders an error for the select
    */
   error: PropTypes.string,
+  /**
+   * renders the error message
+   */
+  errorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/Textarea.js
+++ b/src/components/Form/Textarea.js
@@ -15,7 +15,7 @@ const Textarea = (props) => {
     className,
     disabled,
     error,
-    errorMessage,
+    hideErrorMessage,
     hideLabel,
     id,
     label,
@@ -49,7 +49,7 @@ const Textarea = (props) => {
         placeholder={placeholder}
         disabled={disabled}
         required={required}
-        aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
+        aria-describedby={error && !hideErrorMessage ? getUniqueHash(error, id) : null}
       />
     );
   };
@@ -60,7 +60,7 @@ const Textarea = (props) => {
       <FormElementControl className={cx({ 'slds-border_bottom': readOnly })}>
         {renderContent()}
       </FormElementControl>
-      {errorMessage && <FormElementError error={error} id={id} />}
+      {!hideErrorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -69,7 +69,7 @@ Textarea.defaultProps = {
   className: null,
   disabled: null,
   error: null,
-  errorMessage: true,
+  hideErrorMessage: false,
   hideLabel: false,
   onChange: () => {},
   readOnly: false,
@@ -92,7 +92,7 @@ Textarea.propTypes = {
   /**
    * renders the error message
    */
-  errorMessage: PropTypes.bool,
+  hideErrorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/Textarea.js
+++ b/src/components/Form/Textarea.js
@@ -15,6 +15,7 @@ const Textarea = (props) => {
     className,
     disabled,
     error,
+    errorMessage,
     hideLabel,
     id,
     label,
@@ -48,7 +49,7 @@ const Textarea = (props) => {
         placeholder={placeholder}
         disabled={disabled}
         required={required}
-        aria-describedby={error ? getUniqueHash(error, id) : null}
+        aria-describedby={error && errorMessage ? getUniqueHash(error, id) : null}
       />
     );
   };
@@ -59,7 +60,7 @@ const Textarea = (props) => {
       <FormElementControl className={cx({ 'slds-border_bottom': readOnly })}>
         {renderContent()}
       </FormElementControl>
-      <FormElementError error={error} id={id} />
+      {errorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
   );
 };
@@ -68,6 +69,7 @@ Textarea.defaultProps = {
   className: null,
   disabled: null,
   error: null,
+  errorMessage: true,
   hideLabel: false,
   onChange: () => {},
   readOnly: false,
@@ -87,6 +89,10 @@ Textarea.propTypes = {
   * renders an error for the textarea
    */
   error: PropTypes.string,
+  /**
+   * renders the error message
+   */
+  errorMessage: PropTypes.bool,
   /**
    * sets the label to render as assistive text
    */

--- a/src/components/Form/__tests__/Checkbox.spec.js
+++ b/src/components/Form/__tests__/Checkbox.spec.js
@@ -53,7 +53,7 @@ describe('<Checkbox />', () => {
   });
 
   it('hides the error message', () => {
-    mounted.setProps({ error: 'shit', errorMessage: false });
+    mounted.setProps({ error: 'shit', hideErrorMessage: true });
     expect(mounted.find('.slds-form-element__help').length).toEqual(0);
     expect(mounted.find('input').prop('aria-describedby')).toEqual(null);
   });

--- a/src/components/Form/__tests__/Checkbox.spec.js
+++ b/src/components/Form/__tests__/Checkbox.spec.js
@@ -52,6 +52,11 @@ describe('<Checkbox />', () => {
     expect(mounted.find('input').prop('aria-describedby')).toEqual(hash);
   });
 
+  it('hides the error message', () => {
+    mounted.setProps({ error: 'shit', errorMessage: false });
+    expect(mounted.find('.slds-form-element__help').length).toEqual(0);
+    expect(mounted.find('input').prop('aria-describedby')).toEqual(null);
+  });
 
   it('applies className and rest-properties', () => {
     mounted.setProps({ className: 'foo', 'data-test': 'bar' });

--- a/src/components/Form/__tests__/CheckboxGroup.spec.js
+++ b/src/components/Form/__tests__/CheckboxGroup.spec.js
@@ -31,7 +31,7 @@ describe('<CheckboxGroup />', () => {
   });
 
   it('hides the error message', () => {
-    mounted.setProps({ error: 'shit', errorMessage: false });
+    mounted.setProps({ error: 'shit', hideErrorMessage: true });
     expect(mounted.find('.slds-form-element__help').length).toEqual(0);
     expect(mounted.find('input').prop('aria-describedby')).toEqual(undefined);
   });

--- a/src/components/Form/__tests__/CheckboxGroup.spec.js
+++ b/src/components/Form/__tests__/CheckboxGroup.spec.js
@@ -30,6 +30,12 @@ describe('<CheckboxGroup />', () => {
     expect(mounted.find('input').prop('aria-describedby')).toEqual(getUniqueHash('shit', props.id));
   });
 
+  it('hides the error message', () => {
+    mounted.setProps({ error: 'shit', errorMessage: false });
+    expect(mounted.find('.slds-form-element__help').length).toEqual(0);
+    expect(mounted.find('input').prop('aria-describedby')).toEqual(undefined);
+  });
+
   it('executes an onChange-handler', () => {
     const mockFn = jest.fn();
     mounted.setProps({ onChange: mockFn });

--- a/src/components/Form/__tests__/Input.spec.js
+++ b/src/components/Form/__tests__/Input.spec.js
@@ -128,6 +128,12 @@ describe('<Input />', () => {
     expect(mounted.find('input').prop('aria-describedby')).toEqual(hash);
   });
 
+  it('hides the error message', () => {
+    mounted.setProps({ error: 'shit', errorMessage: false });
+    expect(mounted.find('.slds-form-element__help').length).toEqual(0);
+    expect(mounted.find('input').prop('aria-describedby')).toEqual(null);
+  });
+
   it('applies hideLabel to the label', () => {
     mounted.setProps({ hideLabel: true });
     expect(mounted.find('FormElementLabel').prop('hideLabel')).toBeTruthy();

--- a/src/components/Form/__tests__/Input.spec.js
+++ b/src/components/Form/__tests__/Input.spec.js
@@ -129,7 +129,7 @@ describe('<Input />', () => {
   });
 
   it('hides the error message', () => {
-    mounted.setProps({ error: 'shit', errorMessage: false });
+    mounted.setProps({ error: 'shit', hideErrorMessage: true });
     expect(mounted.find('.slds-form-element__help').length).toEqual(0);
     expect(mounted.find('input').prop('aria-describedby')).toEqual(null);
   });

--- a/src/components/Form/__tests__/Select.spec.js
+++ b/src/components/Form/__tests__/Select.spec.js
@@ -68,6 +68,12 @@ describe('<Select />', () => {
     expect(mounted.find('select').prop('aria-describedby')).toEqual(hash);
   });
 
+  it('hides the error message', () => {
+    mounted.setProps({ error: 'shit', errorMessage: false });
+    expect(mounted.find('.slds-form-element__help').length).toEqual(0);
+    expect(mounted.find('select').prop('aria-describedby')).toEqual(null);
+  });
+
   it('applies className and rest-properties', () => {
     mounted.setProps({ className: 'foo', 'data-test': 'bar' });
     expect(mounted.find('select').hasClass('foo')).toBeTruthy();

--- a/src/components/Form/__tests__/Select.spec.js
+++ b/src/components/Form/__tests__/Select.spec.js
@@ -69,7 +69,7 @@ describe('<Select />', () => {
   });
 
   it('hides the error message', () => {
-    mounted.setProps({ error: 'shit', errorMessage: false });
+    mounted.setProps({ error: 'shit', hideErrorMessage: true });
     expect(mounted.find('.slds-form-element__help').length).toEqual(0);
     expect(mounted.find('select').prop('aria-describedby')).toEqual(null);
   });

--- a/src/components/Form/__tests__/Textarea.spec.js
+++ b/src/components/Form/__tests__/Textarea.spec.js
@@ -56,6 +56,12 @@ describe('<Textarea />', () => {
     expect(mounted.find('textarea').prop('aria-describedby')).toEqual(hash);
   });
 
+  it('hides the error message', () => {
+    mounted.setProps({ error: 'shit', errorMessage: false });
+    expect(mounted.find('.slds-form-element__help').length).toEqual(0);
+    expect(mounted.find('textarea').prop('aria-describedby')).toEqual(null);
+  });
+
   it('renders a readOnly-version', () => {
     mounted.setProps({ readOnly: true });
     expect(mounted.find('textarea').length).toBe(0);

--- a/src/components/Form/__tests__/Textarea.spec.js
+++ b/src/components/Form/__tests__/Textarea.spec.js
@@ -57,7 +57,7 @@ describe('<Textarea />', () => {
   });
 
   it('hides the error message', () => {
-    mounted.setProps({ error: 'shit', errorMessage: false });
+    mounted.setProps({ error: 'shit', hideErrorMessage: true });
     expect(mounted.find('.slds-form-element__help').length).toEqual(0);
     expect(mounted.find('textarea').prop('aria-describedby')).toEqual(null);
   });


### PR DESCRIPTION
This adds an boolean `errorMessage` flag which can be used, to disable the display of error messages. This allows us to mark (outline) a form element as invalid without showing a message next to it.