### PR TITLE
Fix rendering of mulitple columns in lookup table

### DIFF
--- a/docs/src/app/pages/Lookups/ExampleMultiTable.js
+++ b/docs/src/app/pages/Lookups/ExampleMultiTable.js
@@ -25,7 +25,7 @@ const ExampleMulti = () => {
 
   const tableFields = [
     {
-      name: 'name',
+      name: 'label',
       label: 'Contact Name',
     },
     {

--- a/docs/src/app/pages/Lookups/exampleData.js
+++ b/docs/src/app/pages/Lookups/exampleData.js
@@ -1,37 +1,44 @@
 export default [
   {
     id: '1',
+    email: 'something@example.com',
     label: 'Something',
     meta: 'Very meta',
     objectType: 'contact',
   },
   {
     id: '2',
+    email: 'really@example.com',
     label: 'Really',
     objectType: 'contact',
   },
   {
     id: '3',
+    email: 'notso@example.com',
     label: 'Not so',
     objectType: 'contact',
   },
   {
     id: '4',
+    email: 'muchuseful@example.com',
     label: 'Much useful',
     objectType: 'contact',
   },
   {
     id: '5',
+    email: 'ofanytype@example.com',
     label: 'Of any type',
     objectType: 'contact',
   },
   {
     id: '6',
+    email: 'ofsometype@example.com',
     label: 'Of some type',
     objectType: 'account',
   },
   {
     id: '7',
+    email: 'ofsomerecordtype@example.com',
     label: 'Of some record type',
     objectType: 'record',
   },

--- a/src/components/Lookup/Lookup.js
+++ b/src/components/Lookup/Lookup.js
@@ -465,14 +465,14 @@ export class Lookup extends Component {
       <tbody>
         {displayItems.map(item =>
           <Row key={item.id}>
-            {tableFields.map((field, index) =>
+            {tableFields.map(({ name }, index) =>
               <Cell
-                data-label={field.name}
+                data-label={name}
                 scope={index === 0 ? 'row' : null}
                 onClick={() => this.addSelection(item)}
-                key={item.id}
+                key={`${item.id}-${name}`}
               >
-                {renderBodyCell(item.label, index, item.objectType)}
+                {renderBodyCell(item[name], index, item.objectType)}
               </Cell>
             )}
           </Row>

--- a/src/components/Lookup/__tests__/Lookup.spec.js
+++ b/src/components/Lookup/__tests__/Lookup.spec.js
@@ -10,37 +10,44 @@ describe('<Lookup />', () => {
   const sampleData = [
     {
       id: '1',
+      email: 'something@example.com',
       label: 'Something',
       meta: 'Very meta',
       objectType: 'contact',
     },
     {
       id: '2',
+      email: 'really@example.com',
       label: 'Really',
       objectType: 'contact',
     },
     {
       id: '3',
+      email: 'notso@example.com',
       label: 'Not so',
       objectType: 'contact',
     },
     {
       id: '4',
+      email: 'muchuseful@example.com',
       label: 'Much useful',
       objectType: 'contact',
     },
     {
       id: '5',
+      email: 'ofanytype@example.com',
       label: 'Of any type',
       objectType: 'contact',
     },
     {
       id: '6',
+      email: 'ofsometype@example.com',
       label: 'Of some type',
       objectType: 'account',
     },
     {
       id: '7',
+      email: 'ofsomerecordtype@example.com',
       label: 'Of some record type',
       objectType: 'record',
     },
@@ -103,9 +110,19 @@ describe('<Lookup />', () => {
 
   it('renders a lookup list with table layout', () => {
     mounted.setState({ open: true, loaded: sampleData });
-    mounted.setProps({ table: true, tableFields: [{ name: 'Name', label: 'Name' }] });
+    mounted.setProps({ table: true, tableFields: [{ name: 'label', label: 'Name' }] });
     expect(mounted.find('.slds-lookup__list .slds-lookup__item-action').length).toBe(0);
     expect(mounted.find('table tbody tr').length).toBe(7);
+  });
+
+  it('renders a lookup list with table layout and multiple columns', () => {
+    const tableFields = [{ name: 'label', label: 'Name' }, { name: 'email', label: 'Email' }];
+    mounted.setState({ open: true, loaded: sampleData });
+    mounted.setProps({ table: true, tableFields });
+    const row = mounted.find('table tbody tr').first().children();
+    expect(row.length).toBe(2);
+    expect(row.at(0).text()).toBe('Something');
+    expect(row.at(1).text()).toBe('something@example.com');
   });
 
   it('renders lookup items correctly', () => {


### PR DESCRIPTION
The lookup table layout currently only renders the first column. There are two issues with the current code:

- It uses the row id as a key for the table cells, which results in only one cell per row being displayed
- It always uses the `label` property from the row item as content for each cell, which would result in every cell per row rendering the same content (if it would be displayed in the first place).

I changed this to use the `tableFields.name` prop as a selector for the cell content and came up with an unique key scheme for table cells. Hope this is how it should work. 
I don't expect any backwards compatibility issues because with the current version of the code, i doubt anyone is using this feature at the moment.