### PR TITLE
Fix export of missing component

### DIFF
--- a/src/components/PageHeader/ObjectHome.js
+++ b/src/components/PageHeader/ObjectHome.js
@@ -6,7 +6,7 @@ import omit from 'lodash.omit';
 
 import { Grid, Column, Menu } from '../../';
 
-class ObjectHomeRaw extends Component {
+export class ObjectHomeRaw extends Component {
   static propTypes = {
     /**
      * bottom Buttons or ButtonGroup(s)

--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -1,5 +1,5 @@
-import ObjectHome, { ObjectHomeRaw } from './ObjectHome';
+import ObjectHome from './ObjectHome';
 import PageHeaderBase from './PageHeaderBase';
 import RecordHome from './RecordHome';
 
-export { ObjectHome, ObjectHomeRaw, PageHeaderBase, RecordHome };
+export { ObjectHome, PageHeaderBase, RecordHome };

--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -1,5 +1,5 @@
-import ObjectHome from './ObjectHome';
+import ObjectHome, { ObjectHomeRaw } from './ObjectHome';
 import PageHeaderBase from './PageHeaderBase';
 import RecordHome from './RecordHome';
 
-export { ObjectHome, PageHeaderBase, RecordHome };
+export { ObjectHome, ObjectHomeRaw, PageHeaderBase, RecordHome };


### PR DESCRIPTION
I'm just assuming that the export should be removed, because it isn't exported from `ObjectHome.js` anymore.