### PR TITLE
Fix issues with removed `propTypes`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "react/forbid-prop-types": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/no-array-index-key": 1,
-    "react/require-default-props": 1
+    "react/require-default-props": 1,
+    "react/forbid-foreign-prop-types": "error"
   }
 }

--- a/src/components/Accordion/Accordion.js
+++ b/src/components/Accordion/Accordion.js
@@ -3,6 +3,34 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omit from 'lodash.omit';
 
+// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
+const propTypes = {
+  /**
+   * sections
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * class name
+   */
+  className: PropTypes.string,
+  /**
+    * which section should be open by default, defaults to first
+    */
+  defaultOpen: PropTypes.string,
+  /**
+    * wraps the component in a card
+    */
+  styled: PropTypes.bool,
+  /*
+   * controlled mode: id of open section
+   */
+  open: PropTypes.string,
+  /*
+   * controlled mode: section click handler
+   */
+  onSectionClick: PropTypes.func,
+};
+
 class Accordion extends Component {
   static defaultProps = {
     className: null,
@@ -12,32 +40,7 @@ class Accordion extends Component {
     onSectionClick: null,
   }
 
-  static propTypes = {
-    /**
-     * sections
-     */
-    children: PropTypes.node.isRequired,
-    /**
-     * class name
-     */
-    className: PropTypes.string,
-    /**
-      * which section should be open by default, defaults to first
-      */
-    defaultOpen: PropTypes.string,
-    /**
-      * wraps the component in a card
-      */
-    styled: PropTypes.bool,
-    /*
-     * controlled mode: id of open section
-     */
-    open: PropTypes.string,
-    /*
-     * controlled mode: section click handler
-     */
-    onSectionClick: PropTypes.func,
-  }
+  static propTypes = propTypes;
 
   constructor(props) {
     super(props);
@@ -70,7 +73,7 @@ class Accordion extends Component {
 
   render() {
     const { className, styled } = this.props;
-    const rest = omit(this.props, Object.keys(Accordion.propTypes));
+    const rest = omit(this.props, Object.keys(propTypes));
 
     const sldsClasses = [
       'slds-accordion',

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 
 import { Table, uniqueId } from '../../';
+import { propTypes as tablePropTypes } from '../Table/Table';
 
 import defaultRowRenderer from './defaultRowRenderer';
 
@@ -235,7 +236,7 @@ DataTable.defaultProps = {
 };
 
 DataTable.propTypes = {
-  ...Table.propTypes,
+  ...tablePropTypes,
 
   /**
    * Table content, an array of objects

--- a/src/components/DataTable/DataTableActionColumn.js
+++ b/src/components/DataTable/DataTableActionColumn.js
@@ -1,11 +1,11 @@
 import { Component } from 'react';
 
-import DataTableColumn from './DataTableColumn';
+import DataTableColumn, { propTypes as columnPropTypes } from './DataTableColumn';
 import defaultActionHeadRenderer from './defaultActionHeadRenderer';
 
 class DataTableActionColumn extends Component {
   static propTypes = {
-    ...DataTableColumn.propTypes
+    ...columnPropTypes
   }
 
   static defaultProps = {

--- a/src/components/DataTable/DataTableColumn.js
+++ b/src/components/DataTable/DataTableColumn.js
@@ -4,17 +4,19 @@ import PropTypes from 'prop-types';
 import defaultCellRenderer from './defaultCellRenderer';
 import defaultHeadRenderer from './defaultHeadRenderer';
 
+/* eslint-disable react/no-unused-prop-types */
+export const propTypes = {
+  cellRenderer: PropTypes.func.isRequired,
+  headRenderer: PropTypes.func.isRequired,
+  dataKey: PropTypes.string.isRequired,
+  isResizable: PropTypes.bool,
+  sortable: PropTypes.bool,
+  title: PropTypes.string,
+};
+// eslint-enable
+
 class DataTableColumn extends Component {
-  /* eslint-disable react/no-unused-prop-types */
-  static propTypes = {
-    cellRenderer: PropTypes.func.isRequired,
-    headRenderer: PropTypes.func.isRequired,
-    dataKey: PropTypes.string.isRequired,
-    isResizable: PropTypes.bool,
-    sortable: PropTypes.bool,
-    title: PropTypes.string,
-  }
-  // eslint-enable
+  static propTypes = propTypes
 
   static defaultProps = {
     cellRenderer: defaultCellRenderer,

--- a/src/components/DataTable/DataTableSelectColumn.js
+++ b/src/components/DataTable/DataTableSelectColumn.js
@@ -1,12 +1,12 @@
 import { Component } from 'react';
 
-import DataTableColumn from './DataTableColumn';
+import DataTableColumn, { propTypes as columnPropTypes } from './DataTableColumn';
 import defaultSelectAllRenderer from './defaultSelectAllRenderer';
 import defaultSelectRenderer from './defaultSelectRenderer';
 
 class DataTableSelectColumn extends Component {
   static propTypes = {
-    ...DataTableColumn.propTypes
+    ...columnPropTypes
   }
 
   static defaultProps = {

--- a/src/components/Lookup/Lookup.js
+++ b/src/components/Lookup/Lookup.js
@@ -19,115 +19,119 @@ import {
   Cell,
 } from '../../';
 
+
+// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
+const propTypes = {
+  /**
+   * if set to true, allows the creation of new elements that were not found
+   * during lookups. For example new email addresses.
+   * The new entry will not have an object type and the ID will be the current
+   * timestamp.
+   */
+  allowCreate: PropTypes.bool,
+  /**
+   * class name
+   */
+  className: PropTypes.string,
+  /**
+   * renders a different layour without borders (bare) for email docked
+   * composer
+   */
+  emailLayout: PropTypes.bool,
+  /**
+   * renders an error for the lookup. shows an error messsage if error is a string.
+   */
+  error: PropTypes.string,
+  /**
+   * whether the lookup error message is hidden
+   */
+  hideErrorMessage: PropTypes.bool,
+  /**
+   * whether the lookup label is hidden
+   */
+  hideLabel: PropTypes.bool,
+  /**
+  * id of the input field in the lookup component
+  */
+  id: PropTypes.string.isRequired,
+  /**
+   * initial item selection. use with uncontrolled lookup
+   */
+  initialSelection: PropTypes.array,
+  /**
+   * label for the input field in the lookup component
+   */
+  inputLabel: PropTypes.string.isRequired,
+  /**
+   * label for the dropdown in the lookup component
+   */
+  listLabel: PropTypes.string.isRequired,
+  /**
+   * loads items into the lookup component
+   */
+  load: PropTypes.func.isRequired,
+  /**
+   * set true to call load() onInputChange (defaults to true)
+   */
+  loadOnChange: PropTypes.bool,
+  /**
+   * set true to call load() onInputFocus (defaults to false)
+   */
+  loadOnFocus: PropTypes.bool,
+  /**
+   * set true to call load() onComponentDidMount (defaults to false)
+   */
+  loadOnMount: PropTypes.bool,
+  /**
+   * renders the lookup in multiple mode
+   */
+  multi: PropTypes.bool,
+  /**
+   * type of object that is queried via the lookup. if it changes, loaded items will be reset
+   */
+  objectType: PropTypes.string,
+  /**
+   * onChange handler for the lookup. has selected items as first argument
+   */
+  onChange: PropTypes.func.isRequired,
+  /**
+   * onFocus handler for the input field in the lookup
+   */
+  onFocus: PropTypes.func,
+  /**
+   * placeholder for the input field in lookup
+   */
+  placeholder: PropTypes.string,
+  /**
+   * Callback for rendering a single selection pill.
+   */
+  renderSelection: PropTypes.func,
+  /**
+   * Marks the field as required
+   */
+  required: PropTypes.bool,
+  /**
+   * current item selection. use with controlled lookup
+   */
+  selection: PropTypes.array,
+  /**
+   * if set, renders the Advanced Modal table layout
+   */
+  table: PropTypes.bool,
+  tableFields: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    })
+  ),
+  /**
+   * Label behind the number of Results in the table header
+   */
+  tableResultsHeading: PropTypes.string,
+};
+
 export class LookupRaw extends Component {
-  static propTypes = {
-    /**
-     * if set to true, allows the creation of new elements that were not found
-     * during lookups. For example new email addresses.
-     * The new entry will not have an object type and the ID will be the current
-     * timestamp.
-     */
-    allowCreate: PropTypes.bool,
-    /**
-     * class name
-     */
-    className: PropTypes.string,
-    /**
-     * renders a different layour without borders (bare) for email docked
-     * composer
-     */
-    emailLayout: PropTypes.bool,
-    /**
-     * renders an error for the lookup. shows an error messsage if error is a string.
-     */
-    error: PropTypes.string,
-    /**
-     * whether the lookup error message is hidden
-     */
-    hideErrorMessage: PropTypes.bool,
-    /**
-     * whether the lookup label is hidden
-     */
-    hideLabel: PropTypes.bool,
-    /**
-    * id of the input field in the lookup component
-    */
-    id: PropTypes.string.isRequired,
-    /**
-     * initial item selection. use with uncontrolled lookup
-     */
-    initialSelection: PropTypes.array,
-    /**
-     * label for the input field in the lookup component
-     */
-    inputLabel: PropTypes.string.isRequired,
-    /**
-     * label for the dropdown in the lookup component
-     */
-    listLabel: PropTypes.string.isRequired,
-    /**
-     * loads items into the lookup component
-     */
-    load: PropTypes.func.isRequired,
-    /**
-     * set true to call load() onInputChange (defaults to true)
-     */
-    loadOnChange: PropTypes.bool,
-    /**
-     * set true to call load() onInputFocus (defaults to false)
-     */
-    loadOnFocus: PropTypes.bool,
-    /**
-     * set true to call load() onComponentDidMount (defaults to false)
-     */
-    loadOnMount: PropTypes.bool,
-    /**
-     * renders the lookup in multiple mode
-     */
-    multi: PropTypes.bool,
-    /**
-     * type of object that is queried via the lookup. if it changes, loaded items will be reset
-     */
-    objectType: PropTypes.string,
-    /**
-     * onChange handler for the lookup. has selected items as first argument
-     */
-    onChange: PropTypes.func.isRequired,
-    /**
-     * onFocus handler for the input field in the lookup
-     */
-    onFocus: PropTypes.func,
-    /**
-     * placeholder for the input field in lookup
-     */
-    placeholder: PropTypes.string,
-    /**
-     * Callback for rendering a single selection pill.
-     */
-    renderSelection: PropTypes.func,
-    /**
-     * Marks the field as required
-     */
-    required: PropTypes.bool,
-    /**
-     * current item selection. use with controlled lookup
-     */
-    selection: PropTypes.array,
-    /**
-     * if set, renders the Advanced Modal table layout
-     */
-    table: PropTypes.bool,
-    tableFields: PropTypes.arrayOf(
-      PropTypes.shape({
-        name: PropTypes.string.isRequired,
-        label: PropTypes.string.isRequired,
-      })
-    ),
-    /**
-     * Label behind the number of Results in the table header
-     */
-    tableResultsHeading: PropTypes.string,
-  };
+  static propTypes = propTypes;
 
   static defaultProps = {
     allowCreate: false,
@@ -559,7 +563,7 @@ export class LookupRaw extends Component {
     } = this.props;
     const { open } = this.state;
 
-    const rest = omit(this.props, Object.keys(LookupRaw.propTypes));
+    const rest = omit(this.props, Object.keys(propTypes));
 
     const sldsClasses = [
       'slds-lookup',

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -6,7 +6,83 @@ import omit from 'lodash.omit';
 
 import { Button, ButtonIcon } from '../../';
 
+// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
+const propTypes = {
+  /**
+   * The button that triggers the dropdown menu
+   * ```
+   * {
+   *    icon: 'settings',
+   *    sprite: 'utility',
+   *    title: 'Click me',
+   *    noBorder: true,
+   * }
+   * ```
+   */
+  button: PropTypes.shape({
+    brand: PropTypes.bool,
+    icon: PropTypes.string.isRequired,
+    neutral: PropTypes.bool,
+    noBorder: PropTypes.bool,
+    sprite: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    tooltip: PropTypes.string,
+  }),
+  /**
+   * one MenuList or many of them
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * class name
+   */
+  className: PropTypes.string,
+  /**
+   * fully customizable dropdown trigger button, use this instead of the button
+   * shape if needed
+   */
+  customButton: PropTypes.element,
+  /**
+   * adds disabled attribute to menu button
+   */
+  disabled: PropTypes.bool,
+  /**
+   * forces open or closed state, is needed when using a custom button
+   */
+  isOpen: PropTypes.bool,
+  /**
+   * indicates that this is the last element inside a button group and renders
+   * the required css class
+   */
+  last: PropTypes.bool,
+  /**
+   * displays the nubbin at the correct position if true, hidden per default
+   */
+  nubbin: PropTypes.bool,
+  /**
+   * position relative to the menu button
+   */
+  position: PropTypes.oneOf(['top-left', 'top', 'top-right', 'bottom-left', 'bottom', 'bottom-right']),
+  /**
+   * length of the menu box
+   */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
 export class MenuRaw extends Component {
+  static propTypes = propTypes
+
+  static defaultProps = {
+    button: null,
+    className: null,
+    customButton: null,
+    disabled: false,
+    isOpen: false,
+    last: false,
+    nubbin: false,
+    position: 'top-left',
+    size: 'small',
+  }
+
   constructor(props, { cssPrefix }) {
     super(props, { cssPrefix });
     this.state = { open: this.props.isOpen };
@@ -80,7 +156,7 @@ export class MenuRaw extends Component {
       className,
     ];
 
-    const rest = omit(this.props, Object.keys(MenuRaw.propTypes));
+    const rest = omit(this.props, Object.keys(propTypes));
 
     return (
       <div className={cx(this.getClasses())}>
@@ -92,78 +168,5 @@ export class MenuRaw extends Component {
     );
   }
 }
-
-MenuRaw.propTypes = {
-  /**
-   * The button that triggers the dropdown menu
-   * ```
-   * {
-   *    icon: 'settings',
-   *    sprite: 'utility',
-   *    title: 'Click me',
-   *    noBorder: true,
-   * }
-   * ```
-   */
-  button: PropTypes.shape({
-    brand: PropTypes.bool,
-    icon: PropTypes.string.isRequired,
-    neutral: PropTypes.bool,
-    noBorder: PropTypes.bool,
-    sprite: PropTypes.string.isRequired,
-    title: PropTypes.string,
-    tooltip: PropTypes.string,
-  }),
-  /**
-   * one MenuList or many of them
-   */
-  children: PropTypes.node.isRequired,
-  /**
-   * class name
-   */
-  className: PropTypes.string,
-  /**
-   * fully customizable dropdown trigger button, use this instead of the button
-   * shape if needed
-   */
-  customButton: PropTypes.element,
-  /**
-   * adds disabled attribute to menu button
-   */
-  disabled: PropTypes.bool,
-  /**
-   * forces open or closed state, is needed when using a custom button
-   */
-  isOpen: PropTypes.bool,
-  /**
-   * indicates that this is the last element inside a button group and renders
-   * the required css class
-   */
-  last: PropTypes.bool,
-  /**
-   * displays the nubbin at the correct position if true, hidden per default
-   */
-  nubbin: PropTypes.bool,
-  /**
-   * position relative to the menu button
-   */
-  position: PropTypes.oneOf(['top-left', 'top', 'top-right', 'bottom-left', 'bottom', 'bottom-right']),
-  /**
-   * length of the menu box
-   */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-};
-
-MenuRaw.defaultProps = {
-  button: null,
-  className: null,
-  customButton: null,
-  disabled: false,
-  isOpen: false,
-  last: false,
-  nubbin: false,
-  position: 'top-left',
-  size: 'small',
-};
 
 export default enhanceWithClickOutside(MenuRaw);

--- a/src/components/PageHeader/ObjectHome.js
+++ b/src/components/PageHeader/ObjectHome.js
@@ -6,38 +6,41 @@ import omit from 'lodash.omit';
 
 import { Grid, Column, Menu } from '../../';
 
+// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
+const propTypes = {
+  /**
+   * bottom Buttons or ButtonGroup(s)
+   */
+  bottomButtons: PropTypes.node,
+  /**
+   * class name
+   */
+  className: PropTypes.string,
+  /**
+   * info that is displayed below the title
+   */
+  info: PropTypes.string,
+  /**
+   * record type header above the title
+   */
+  recordType: PropTypes.string.isRequired,
+  /**
+   * title
+   */
+  title: PropTypes.string.isRequired,
+  /**
+   * dropdown header menu that also get's triggered when a user clicks on the
+   * title headline. Must be one or more instances of MenuDropdownList
+   */
+  titleMenu: PropTypes.node,
+  /**
+   * top Buttons or ButtonGroup(s)
+   */
+  topButtons: PropTypes.node,
+};
+
 export class ObjectHomeRaw extends Component {
-  static propTypes = {
-    /**
-     * bottom Buttons or ButtonGroup(s)
-     */
-    bottomButtons: PropTypes.node,
-    /**
-     * class name
-     */
-    className: PropTypes.string,
-    /**
-     * info that is displayed below the title
-     */
-    info: PropTypes.string,
-    /**
-     * record type header above the title
-     */
-    recordType: PropTypes.string.isRequired,
-    /**
-     * title
-     */
-    title: PropTypes.string.isRequired,
-    /**
-     * dropdown header menu that also get's triggered when a user clicks on the
-     * title headline. Must be one or more instances of MenuDropdownList
-     */
-    titleMenu: PropTypes.node,
-    /**
-     * top Buttons or ButtonGroup(s)
-     */
-    topButtons: PropTypes.node,
-  };
+  static propTypes = propTypes;
 
   static defaultProps = {
     bottomButtons: null,
@@ -62,7 +65,7 @@ export class ObjectHomeRaw extends Component {
 
   render() {
     const { bottomButtons, className, info, recordType, title, titleMenu, topButtons } = this.props;
-    const rest = omit(this.props, Object.keys(ObjectHomeRaw.propTypes));
+    const rest = omit(this.props, Object.keys(propTypes));
 
     const sldsClasses = [
       'slds-page-header',

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -6,7 +6,81 @@ import { THEMES, getThemeClass } from '../../utils';
 
 import { Button, ButtonIcon } from '../../';
 
+// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
+const propTypes = {
+  /**
+   * Open popover
+   */
+  open: PropTypes.bool,
+  /**
+   * Show close button
+   */
+  closeable: PropTypes.bool,
+  /**
+   * onClose handler
+   */
+  onClose: PropTypes.func.isRequired,
+  /**
+   * Popover header content
+   */
+  header: PropTypes.node,
+  /**
+   * Popover body content
+   */
+  body: PropTypes.node,
+  /**
+   * Popover footer content
+   */
+  footer: PropTypes.node,
+  /**
+   * Additional css classes
+   */
+  className: PropTypes.string,
+  /**
+   * Optional panel layout
+   */
+  panels: PropTypes.bool,
+  /**
+   * Optional position of nubbin. Positions: left, left-top, left-bottom,
+   * top-left, top-right, right-top, right-bottom, bottom-left, bottom-right
+   */
+  nubbin: PropTypes.oneOf([
+    'left',
+    'left-top',
+    'left-bottom',
+    'top-left',
+    'top-right',
+    'right-top',
+    'right-bottom',
+    'bottom-left',
+    'bottom-right',
+  ]),
+  /**
+   * Optional custom Header theme. Themes: warning, error, success, info
+   */
+  customHeaderTheme: PropTypes.oneOf(THEMES),
+  /**
+   * themes: alt-inverse, default, error, info, inverse, offline, shade, success, warning
+   */
+  theme: PropTypes.oneOf(THEMES),
+};
+
 class Popover extends Component {
+  static propTypes = propTypes
+
+  static defaultProps = {
+    body: null,
+    header: null,
+    footer: null,
+    className: null,
+    customHeaderTheme: null,
+    open: false,
+    closeable: true,
+    panels: false,
+    nubbin: 'bottom-left',
+    theme: null,
+  }
+
   static shouldInvertIcon(themeStr) {
     if (typeof themeStr === 'string') {
       return themeStr.includes('error') ||
@@ -90,7 +164,7 @@ class Popover extends Component {
 
   render() {
     const { className, closeable, open, customHeaderTheme, nubbin, panels, header, body, footer, theme } = this.props;
-    const rest = omit(this.props, Object.keys(Popover.propTypes));
+    const rest = omit(this.props, Object.keys(propTypes));
 
     const sldsClasses = [
       'slds-popover',
@@ -115,76 +189,5 @@ class Popover extends Component {
     );
   }
 }
-
-Popover.defaultProps = {
-  body: null,
-  header: null,
-  footer: null,
-  className: null,
-  customHeaderTheme: null,
-  open: false,
-  closeable: true,
-  panels: false,
-  nubbin: 'bottom-left',
-  theme: null,
-};
-
-Popover.propTypes = {
-  /**
-   * Open popover
-   */
-  open: PropTypes.bool,
-  /**
-   * Show close button
-   */
-  closeable: PropTypes.bool,
-  /**
-   * onClose handler
-   */
-  onClose: PropTypes.func.isRequired,
-  /**
-   * Popover header content
-   */
-  header: PropTypes.node,
-  /**
-   * Popover body content
-   */
-  body: PropTypes.node,
-  /**
-   * Popover footer content
-   */
-  footer: PropTypes.node,
-  /**
-   * Additional css classes
-   */
-  className: PropTypes.string,
-  /**
-   * Optional panel layout
-   */
-  panels: PropTypes.bool,
-  /**
-   * Optional position of nubbin. Positions: left, left-top, left-bottom,
-   * top-left, top-right, right-top, right-bottom, bottom-left, bottom-right
-   */
-  nubbin: PropTypes.oneOf([
-    'left',
-    'left-top',
-    'left-bottom',
-    'top-left',
-    'top-right',
-    'right-top',
-    'right-bottom',
-    'bottom-left',
-    'bottom-right',
-  ]),
-  /**
-   * Optional custom Header theme. Themes: warning, error, success, info
-   */
-  customHeaderTheme: PropTypes.oneOf(THEMES),
-  /**
-   * themes: alt-inverse, default, error, info, inverse, offline, shade, success, warning
-   */
-  theme: PropTypes.oneOf(THEMES),
-};
 
 export default Popover;

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -3,30 +3,33 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omit from 'lodash.omit';
 
+// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
+const propTypes = {
+  /**
+   * class name
+   */
+  className: PropTypes.string,
+  /**
+   * array of tabs
+   */
+  tabs: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    content: PropTypes.node.isRequired,
+  })).isRequired,
+  /**
+   * scoped has a border around the tab
+   */
+  scoped: PropTypes.bool,
+};
+
 class Tab extends Component {
   static defaultProps = {
     className: null,
     scoped: false,
   }
 
-  static propTypes = {
-    /**
-     * class name
-     */
-    className: PropTypes.string,
-    /**
-     * array of tabs
-     */
-    tabs: PropTypes.arrayOf(PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      id: PropTypes.string.isRequired,
-      content: PropTypes.node.isRequired,
-    })).isRequired,
-    /**
-     * scoped has a border around the tab
-     */
-    scoped: PropTypes.bool,
-  };
+  static propTypes = propTypes
 
   constructor(props, context) {
     super(props, context);
@@ -99,7 +102,7 @@ class Tab extends Component {
 
   render() {
     const { className, scoped } = this.props;
-    const rest = omit(this.props, Object.keys(Tab.propTypes));
+    const rest = omit(this.props, Object.keys(propTypes));
 
     const sldsClasses = [
       `slds-tabs_${scoped ? 'scoped' : 'default'}`,

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -17,14 +17,8 @@ const Table = (props) => {
   return (<table {...rest} className={cx(sldsClasses)}>{children}</table>);
 };
 
-Table.defaultProps = {
-  children: null,
-  className: null,
-  variation: [],
-  flavor: [],
-};
-
-Table.propTypes = {
+// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
+export const propTypes = {
   /**
    * table content
    */
@@ -54,5 +48,14 @@ Table.propTypes = {
     'fixed-layout',
   ]),
 };
+
+Table.defaultProps = {
+  children: null,
+  className: null,
+  variation: [],
+  flavor: [],
+};
+
+Table.propTypes = propTypes;
 
 export default Table;


### PR DESCRIPTION
Reason for this is, that there are multiple places were the code depends on the `propTypes` being present, for example `src/components/Lookup/Lookup.js` in `render()`:

```
const rest = omit(this.props, Object.keys(LookupRaw.propTypes));
```

This causes no prop being omitted in a production build (because `LookupRaw.propTypes` is an empty object) which will pass `Lookup`'s `onChange` callback down to the form input. This results in stale dom event objects ending up as a `Lookup` selection because the `keypress` events are passed to the `onChange` callback of `Lookup`.

You can use this regex to grep for all similar usages of `propTypes`: `\.propTypes(?!\s?=)`

I changed all of these to explicitly export the `propTypes` and added the eslint-rule to mark all future usages of `propTypes` as an error.

See the following links for details:

https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md