### PR TITLE
Fix column rendering when `children` is a nested array

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -109,11 +109,8 @@ class DataTable extends Component {
     const { children } = this.props;
 
     if (children) {
-      const childrenArray = Array.isArray(children)
-        ? children
-        : [children];
       this.setState({
-        columns: childrenArray
+        columns: React.Children.toArray(children)
           .filter(child => React.isValidElement(child))
           .map(child => child.props),
       });


### PR DESCRIPTION
In a situation like this:

```
<DataTable>
   <DataTableColumn .../>
  {columns.map(column => <DataTableColumn .../>)}
</DataTable>
```

only the first column would be rendered (because `children` is not a flat array in this case). This change fixes that behaviour.