### PR TITLE
Allow dom-nodes in labels for richer styles

### DIFF
--- a/src/components/Form/CheckboxGroup.js
+++ b/src/components/Form/CheckboxGroup.js
@@ -85,7 +85,10 @@ CheckboxGroup.propTypes = {
   /**
    * label
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]).isRequired,
   /**
    * onchange handler
    */

--- a/src/components/Form/CheckboxRaw.js
+++ b/src/components/Form/CheckboxRaw.js
@@ -105,7 +105,10 @@ CheckboxRaw.propTypes = {
   /**
    * label
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]).isRequired,
   /**
    * onChange handler
    */

--- a/src/components/Form/FormElementLabel.js
+++ b/src/components/Form/FormElementLabel.js
@@ -69,7 +69,10 @@ FormElementLabel.propTypes = {
   /**
    * label content
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]).isRequired,
   /**
    * Renders as a html5 legend
    */

--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -145,7 +145,10 @@ Input.propTypes = {
   /**
    * label for the input
    */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
   /**
    * onChange handler for input
    */

--- a/src/components/Form/InputRaw.js
+++ b/src/components/Form/InputRaw.js
@@ -212,7 +212,10 @@ InputRaw.propTypes = {
   /**
    * label for the input
    */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
   /**
    * onChange handler for input
    */

--- a/src/components/Form/Picklist.js
+++ b/src/components/Form/Picklist.js
@@ -161,7 +161,10 @@ PicklistRaw.propTypes = {
   /**
    * label for input label
    */
-  labelInput: PropTypes.string,
+  labelInput: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
   /**
    * label for multiple selected items
    */

--- a/src/components/Form/PicklistDropdown.js
+++ b/src/components/Form/PicklistDropdown.js
@@ -111,7 +111,10 @@ PicklistDropdown.propTypes = {
   /**
    * label for the input
    */
-  labelInput: PropTypes.string,
+  labelInput: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
   /**
    * indicates if the input is required
    */

--- a/src/components/Form/Select.js
+++ b/src/components/Form/Select.js
@@ -108,7 +108,10 @@ Select.propTypes = {
   /**
    * label for the select
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]).isRequired,
   /**
    * adds the multiple attribute to the select
    */

--- a/src/components/Form/Textarea.js
+++ b/src/components/Form/Textarea.js
@@ -104,7 +104,10 @@ Textarea.propTypes = {
   /**
    * label for the textarea
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]).isRequired,
   /**
    * onChange handler for the textarea
    */

--- a/src/components/Lookup/Lookup.js
+++ b/src/components/Lookup/Lookup.js
@@ -61,7 +61,10 @@ const propTypes = {
   /**
    * label for the input field in the lookup component
    */
-  inputLabel: PropTypes.string.isRequired,
+  inputLabel: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]).isRequired,
   /**
    * label for the dropdown in the lookup component
    */


### PR DESCRIPTION
Useful for example to put a badge or emphasis into a label.