### PR TITLE
Add CheckboxToggle

### DIFF
--- a/src/components/CheckboxToggle/CheckboxToggle.js
+++ b/src/components/CheckboxToggle/CheckboxToggle.js
@@ -87,11 +87,11 @@ CheckboxToggle.propTypes = {
    */
   hideLabel: PropTypes.bool,
   /**
-   * Hide the status labels beneath the checkbox
+   * Hide the status labels beneath the checkbox (still visible for screen readers)
    */
   hideStatusLabels: PropTypes.bool,
   /**
-   * Status labels beneath the checkbox (still visible for screen readers)
+   * Status labels beneath the checkbox
    */
   statusLabels: PropTypes.shape({
     unchecked: PropTypes.string.isRequired,

--- a/src/components/CheckboxToggle/CheckboxToggle.js
+++ b/src/components/CheckboxToggle/CheckboxToggle.js
@@ -22,6 +22,7 @@ const CheckboxToggle = (props) => {
 
 
   const descId = `${id}-description`;
+  const statusHidden = hiddenWhen(hideStatusLabels);
 
   return (
     <FormElement>
@@ -45,8 +46,8 @@ const CheckboxToggle = (props) => {
           aria-live="assertive"
         >
           <span className="slds-checkbox_faux" />
-          <span className={cx('slds-checkbox_on', hiddenWhen(hideStatusLabels))}>{labelChecked}</span>
-          <span className={cx('slds-checkbox_off', hiddenWhen(hideStatusLabels))}>{labelUnchecked}</span>
+          <span className={cx('slds-checkbox_on', statusHidden)}>{labelChecked}</span>
+          <span className={cx('slds-checkbox_off', statusHidden)}>{labelUnchecked}</span>
         </span>
       </label>
     </FormElement>
@@ -72,7 +73,6 @@ CheckboxToggle.propTypes = {
   /**
    * Checkbox label
    */
-
   label: PropTypes.string.isRequired,
   /**
    * :checked state. Pass `null` for an uncontrolled checkbox

--- a/src/components/CheckboxToggle/CheckboxToggle.js
+++ b/src/components/CheckboxToggle/CheckboxToggle.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { FormElement } from '../Form';
+
+const hiddenWhen = hidden => ({ 'slds-assistive-text': hidden });
+
+const CheckboxToggle = (props) => {
+  const {
+    checked,
+    disabled,
+    hideStatusLabels,
+    hideLabel,
+    id,
+    label,
+    statusLabels: {
+      unchecked: labelUnchecked,
+      checked: labelChecked,
+    },
+    ...rest
+  } = props;
+
+
+  const descId = `${id}-description`;
+
+  return (
+    <FormElement>
+      <label className="slds-checkbox_toggle slds-grid">
+        <span className={cx('slds-form-element__label', 'slds-m-bottom_none', hiddenWhen(hideLabel))}>
+          {label}
+        </span>
+        <input
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          id={id}
+          aria-describedby={descId}
+          {...rest}
+          name="checkbox"
+          value={checked ? 'on' : 'off'}
+        />
+        <span
+          id={descId}
+          className="slds-checkbox_faux_container"
+          aria-live="assertive"
+        >
+          <span className="slds-checkbox_faux" />
+          <span className={cx('slds-checkbox_on', hiddenWhen(hideStatusLabels))}>{labelChecked}</span>
+          <span className={cx('slds-checkbox_off', hiddenWhen(hideStatusLabels))}>{labelUnchecked}</span>
+        </span>
+      </label>
+    </FormElement>
+  );
+};
+
+CheckboxToggle.defaultProps = {
+  checked: false,
+  disabled: false,
+  hideLabel: false,
+  hideStatusLabels: false,
+  statusLabels: {
+    unchecked: 'Disabled',
+    checked: 'Enabled'
+  }
+};
+
+CheckboxToggle.propTypes = {
+  /**
+   * Unique Id
+   */
+  id: PropTypes.string.isRequired,
+  /**
+   * Checkbox label
+   */
+
+  label: PropTypes.string.isRequired,
+  /**
+   * :checked state. Pass `null` for an uncontrolled checkbox
+   */
+  checked: PropTypes.bool,
+  /**
+   * Disable the checkbox
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Hides the checkbox label (still visible for screen readers)
+   */
+  hideLabel: PropTypes.bool,
+  /**
+   * Hide the status labels beneath the checkbox
+   */
+  hideStatusLabels: PropTypes.bool,
+  /**
+   * Status labels beneath the checkbox (still visible for screen readers)
+   */
+  statusLabels: PropTypes.shape({
+    unchecked: PropTypes.string.isRequired,
+    checked: PropTypes.string.isRequired,
+  })
+};
+
+export default CheckboxToggle;

--- a/src/components/CheckboxToggle/__tests__/CheckboxToggle.spec.js
+++ b/src/components/CheckboxToggle/__tests__/CheckboxToggle.spec.js
@@ -2,39 +2,39 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import CheckboxToggle from '../CheckboxToggle';
 
-const getCmp = (props = {}) => shallow(<CheckboxToggle id="foo" label="bar" {...props} />);
+const getComponent = (props = {}) => shallow(<CheckboxToggle id="foo" label="bar" {...props} />);
 
 const isHidden = (cmp, el) => cmp.find(el).hasClass('slds-assistive-text');
 
 describe('<CheckboxToggle />', () => {
   it('applies rest props to input', () => {
     const mockFn = jest.fn();
-    const cmp = getCmp({ onChange: mockFn });
+    const cmp = getComponent({ onChange: mockFn });
     cmp.find('input').simulate('change');
     expect(mockFn).toHaveBeenCalled();
   });
 
   it('links input to label', () => {
-    const cmp = getCmp();
+    const cmp = getComponent();
     const inputProp = cmp.find('input').prop('aria-describedby');
     const labelProp = cmp.find('.slds-checkbox_faux_container').prop('id');
     expect(inputProp).toEqual(labelProp);
   });
 
   it('defaults to rendering all labels', () => {
-    const cmp = getCmp();
+    const cmp = getComponent();
     expect(isHidden(cmp, '.slds-form-element__label')).toBeFalsy();
     expect(isHidden(cmp, '.slds-checkbox_on')).toBeFalsy();
     expect(isHidden(cmp, '.slds-checkbox_off')).toBeFalsy();
   });
 
   it('allows hiding the label', () => {
-    const cmp = getCmp({ hideLabel: true });
+    const cmp = getComponent({ hideLabel: true });
     expect(isHidden(cmp, '.slds-form-element__label')).toBeTruthy();
   });
 
   it('allows hiding the status labels', () => {
-    const cmp = getCmp({ hideStatusLabels: true });
+    const cmp = getComponent({ hideStatusLabels: true });
     expect(isHidden(cmp, '.slds-checkbox_on')).toBeTruthy();
     expect(isHidden(cmp, '.slds-checkbox_off')).toBeTruthy();
   });

--- a/src/components/CheckboxToggle/__tests__/CheckboxToggle.spec.js
+++ b/src/components/CheckboxToggle/__tests__/CheckboxToggle.spec.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CheckboxToggle from '../CheckboxToggle';
+
+const getCmp = (props = {}) => shallow(<CheckboxToggle id="foo" label="bar" {...props} />);
+
+const isHidden = (cmp, el) => cmp.find(el).hasClass('slds-assistive-text');
+
+describe('<CheckboxToggle />', () => {
+  it('applies rest props to input', () => {
+    const mockFn = jest.fn();
+    const cmp = getCmp({ onChange: mockFn });
+    cmp.find('input').simulate('change');
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  it('links input to label', () => {
+    const cmp = getCmp();
+    const inputProp = cmp.find('input').prop('aria-describedby');
+    const labelProp = cmp.find('.slds-checkbox_faux_container').prop('id');
+    expect(inputProp).toEqual(labelProp);
+  });
+
+  it('defaults to rendering all labels', () => {
+    const cmp = getCmp();
+    expect(isHidden(cmp, '.slds-form-element__label')).toBeFalsy();
+    expect(isHidden(cmp, '.slds-checkbox_on')).toBeFalsy();
+    expect(isHidden(cmp, '.slds-checkbox_off')).toBeFalsy();
+  });
+
+  it('allows hiding the label', () => {
+    const cmp = getCmp({ hideLabel: true });
+    expect(isHidden(cmp, '.slds-form-element__label')).toBeTruthy();
+  });
+
+  it('allows hiding the status labels', () => {
+    const cmp = getCmp({ hideStatusLabels: true });
+    expect(isHidden(cmp, '.slds-checkbox_on')).toBeTruthy();
+    expect(isHidden(cmp, '.slds-checkbox_off')).toBeTruthy();
+  });
+});

--- a/src/components/CheckboxToggle/index.js
+++ b/src/components/CheckboxToggle/index.js
@@ -1,0 +1,3 @@
+import CheckboxToggle from './CheckboxToggle';
+
+export { CheckboxToggle };

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export * from './components/Button';
 export * from './components/ButtonGroup';
 export * from './components/Card';
 export * from './components/Carousel';
+export * from './components/CheckboxToggle';
 export * from './components/Table';
 export * from './components/DataTable';
 export * from './components/Datepicker';

--- a/stories/CheckboxToggle.js
+++ b/stories/CheckboxToggle.js
@@ -25,4 +25,4 @@ stories
       checked={null}
       onChange={action('Change')}
     />
-  ))
+  ));

--- a/stories/CheckboxToggle.js
+++ b/stories/CheckboxToggle.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import { CheckboxToggle } from '../src';
+
+const stories = storiesOf('CheckboxToggle', module);
+
+stories
+  .add('Controlled (Default)', () => (
+    <CheckboxToggle
+      id="toggle-1"
+      label={text('Label', 'ToggleLabel')}
+      checked={boolean('Checked', false)}
+      disabled={boolean('Disabled', false)}
+      onChange={action('Change')}
+      hideStatusLabels={boolean('Hide status labels?', false)}
+      hideLabel={boolean('Hide label?', false)}
+    />
+  ))
+  .add('Uncontrolled', () => (
+    <CheckboxToggle
+      id="toggle-1"
+      label="Toggle Label"
+      checked={null}
+      onChange={action('Change')}
+    />
+  ))


### PR DESCRIPTION
This implements the new [CheckboxToggle](https://lightningdesignsystem.com/components/checkbox-toggle). I took the liberty to amend the hideLabel functionality (done via `slds-assistive-text` to preserve accessibility).

> Reviewers: Docs are incomplete and do not describe the new feature, I guess SF just copied over the Checkbox docs without paying attention (a true LDS classic).