### PR TITLE
Feature/grid order prop

### DIFF
--- a/src/components/Grid/Column.js
+++ b/src/components/Grid/Column.js
@@ -13,8 +13,9 @@ const validBreakpoints = [
   'max-large',
 ];
 
-const breakPointProp = breakpoint => `${breakpoint}-sizeOf`;
+const breakPointProp = (breakpoint, suffix) => `${breakpoint}-${suffix}`;
 const sizeRegex = /^([1-9]|1[0-2])-([1-9]|1[0-2])$/;
+const orderRegex = /^((1[0,1,2])|[1-9])$/;
 
 const Column = (props) => {
   const {
@@ -36,18 +37,25 @@ const Column = (props) => {
   breakpoints.unshift('');
 
   breakpoints.forEach((breakpoint) => {
-    const propName = breakpoint === '' ? 'sizeOf' : breakPointProp(breakpoint);
+    const sizePropName = breakpoint === '' ? 'sizeOf' : breakPointProp(breakpoint, 'sizeOf');
     const sizeString = breakpoint === '' ? 'size' : `${breakpoint}-size`;
-
-    const size = props[propName];
+    const size = props[sizePropName];
     if (sizeRegex.test(size)) {
       const from = parseInt(size.split('-')[0], 10);
       const to = parseInt(size.split('-')[1], 10);
       sldsClasses.push(`slds-${sizeString}_${from}-of-${to}`);
     }
+
+    const orderPropName = breakpoint === '' ? 'order' : breakPointProp(breakpoint, 'order');
+    const orderString = breakpoint === '' ? 'order' : `${breakpoint}-order`;
+    const order = props[orderPropName];
+    if (orderRegex.test(order)) {
+      const position = parseInt(order.split('-')[0], 10);
+      sldsClasses.push(`slds-${orderString}_${position}`);
+    }
   });
 
-  const restProps = omit(rest, validBreakpoints.map(breakPointProp), 'sizeOf');
+  const restProps = omit(rest, validBreakpoints.map(a => breakPointProp(a, 'sizeOf')), 'sizeOf');
 
   return (
     <div {...restProps} className={cx(sldsClasses)}>{children}</div>
@@ -72,6 +80,20 @@ const sizeOfPropType = (props, propName) => {
     if (from > to) {
       return new Error(`${propName} ${size} is impossible. \`${from}\` needs to be smaller than \`${to}\``);
     }
+  }
+
+  return null;
+};
+
+const orderPropType = (props, propName) => {
+  const position = props[propName];
+
+  if (position && !(typeof position === 'string' || typeof position === 'number')) {
+    return new Error(`${propName} must be a string or a number`);
+  }
+
+  if ((typeof position === 'string' || typeof position === 'number') && !orderRegex.test(position)) {
+    return new Error(`${propName} must be of format {1-12}`);
   }
 
   return null;
@@ -105,18 +127,28 @@ Column.propTypes = {
     'shrink',
     'shrink-none',
   ]),
-
   /**
    * omit 'slds-col'
    */
   omitCol: PropTypes.bool,
   /**
-   * non-responsive sizeOf
+   * sizeOf: specify size in fractions like 1-2, 4-12. Breakpoint possible e.g. small-sizeOf="1-2"
    */
   sizeOf: sizeOfPropType, // eslint-disable-line react/require-default-props
   ...validBreakpoints.reduce((_propTypes, breakpoint) => {
+    // this generates sizeOf props for each of the valid breakpoints
     const propTypes = _propTypes;
-    propTypes[breakPointProp(breakpoint)] = sizeOfPropType;
+    propTypes[breakPointProp(breakpoint, 'sizeOf')] = sizeOfPropType;
+    return propTypes;
+  }, {}),
+  /**
+   * order: reorder columns with number from 1 to 12. Breakpoint possible e.g. medium-order="3"
+   */
+  order: orderPropType, // eslint-disable-line react/require-default-props
+  ...validBreakpoints.reduce((_propTypes, breakpoint) => {
+    // this generates order props for each of the valid breakpoints
+    const propTypes = _propTypes;
+    propTypes[breakPointProp(breakpoint, 'order')] = orderPropType;
     return propTypes;
   }, {}),
 };

--- a/src/components/Grid/Column.js
+++ b/src/components/Grid/Column.js
@@ -36,28 +36,32 @@ const Column = (props) => {
   const breakpoints = Array.from(validBreakpoints);
   breakpoints.unshift('');
 
+  const generatedProps = [];
+
   breakpoints.forEach((breakpoint) => {
-    const sizePropName = breakpoint === '' ? 'sizeOf' : breakPointProp(breakpoint, 'sizeOf');
-    const sizeString = breakpoint === '' ? 'size' : `${breakpoint}-size`;
+    const emptyBreakPoint = breakpoint === '';
+
+    const sizePropName = emptyBreakPoint ? 'sizeOf' : breakPointProp(breakpoint, 'sizeOf');
+    const sizeString = emptyBreakPoint ? 'size' : `${breakpoint}-size`;
     const size = props[sizePropName];
-    if (sizeRegex.test(size)) {
+    if (size && sizeRegex.test(size)) {
       const from = parseInt(size.split('-')[0], 10);
       const to = parseInt(size.split('-')[1], 10);
       sldsClasses.push(`slds-${sizeString}_${from}-of-${to}`);
     }
 
-    const orderPropName = breakpoint === '' ? 'order' : breakPointProp(breakpoint, 'order');
-    const orderString = breakpoint === '' ? 'order' : `${breakpoint}-order`;
+    const orderPropName = emptyBreakPoint ? 'order' : breakPointProp(breakpoint, 'order');
+    const orderString = emptyBreakPoint ? 'order' : `${breakpoint}-order`;
     const order = props[orderPropName];
-    if (orderRegex.test(order)) {
+    if (order && orderRegex.test(order)) {
       const position = parseInt(order.split('-')[0], 10);
       sldsClasses.push(`slds-${orderString}_${position}`);
     }
+
+    generatedProps.push(sizePropName, orderPropName);
   });
 
-  let restProps = rest;
-  restProps = omit(restProps, validBreakpoints.map(a => breakPointProp(a, 'sizeOf')), 'sizeOf');
-  restProps = omit(restProps, validBreakpoints.map(a => breakPointProp(a, 'order')), 'order');
+  const restProps = omit(rest, generatedProps);
 
   return (
     <div {...restProps} className={cx(sldsClasses)}>{children}</div>

--- a/src/components/Grid/Column.js
+++ b/src/components/Grid/Column.js
@@ -55,7 +55,9 @@ const Column = (props) => {
     }
   });
 
-  const restProps = omit(rest, validBreakpoints.map(a => breakPointProp(a, 'sizeOf')), 'sizeOf');
+  let restProps = rest;
+  restProps = omit(restProps, validBreakpoints.map(a => breakPointProp(a, 'sizeOf')), 'sizeOf');
+  restProps = omit(restProps, validBreakpoints.map(a => breakPointProp(a, 'order')), 'order');
 
   return (
     <div {...restProps} className={cx(sldsClasses)}>{children}</div>

--- a/src/components/Grid/__tests__/Column.spec.js
+++ b/src/components/Grid/__tests__/Column.spec.js
@@ -37,4 +37,18 @@ describe('<Column />', () => {
     expect(mounted.find('.slds-col').hasClass('slds-shrink')).toBeTruthy();
     expect(mounted.find('.slds-col').hasClass('slds-no-flex')).toBeTruthy();
   });
+
+  it('applies sizeOf classes, with breakpoint and without', () => {
+    mounted.setProps({ sizeOf: '10-12' });
+    expect(mounted.find('.slds-col').hasClass('slds-size_10-of-12')).toBeTruthy();
+    mounted.setProps({ 'small-sizeOf': '10-12' });
+    expect(mounted.find('.slds-col').hasClass('slds-small-size_10-of-12')).toBeTruthy();
+  });
+
+  it('applies order classes, with breakpoint and without', () => {
+    mounted.setProps({ order: '10' });
+    expect(mounted.find('.slds-col').hasClass('slds-order_10')).toBeTruthy();
+    mounted.setProps({ 'small-order': '3' });
+    expect(mounted.find('.slds-col').hasClass('slds-small-order_3')).toBeTruthy();
+  });
 });

--- a/stories/Grid.js
+++ b/stories/Grid.js
@@ -106,7 +106,9 @@ stories
     <Grid wrap>
       <Column
         className="slds-m-bottom--large slds-p-horizontal_small"
-        sizeOf="1-2"
+        sizeOf="1-1"
+        small-sizeOf="1-2"
+        medium-sizeOf="1-4"
         order="1"
         small-order="2"
         medium-order="3"
@@ -115,7 +117,9 @@ stories
       </Column>
       <Column
         className="slds-m-bottom--large slds-p-horizontal_small"
-        sizeOf="1-2"
+        sizeOf="1-1"
+        small-sizeOf="1-2"
+        medium-sizeOf="1-4"
         order="2"
         small-order="1"
         medium-order="2"
@@ -124,7 +128,9 @@ stories
       </Column>
       <Column
         className="slds-m-bottom--large slds-p-horizontal_small"
-        sizeOf="1-2"
+        sizeOf="1-1"
+        small-sizeOf="1-2"
+        medium-sizeOf="1-4"
         order="3"
         small-order="4"
         medium-order="1"
@@ -133,7 +139,9 @@ stories
       </Column>
       <Column
         className="slds-m-bottom--large slds-p-horizontal_small"
-        sizeOf="1-2"
+        sizeOf="1-1"
+        small-sizeOf="1-2"
+        medium-sizeOf="1-4"
         order="4"
         small-order="3"
         medium-order="4"

--- a/stories/Grid.js
+++ b/stories/Grid.js
@@ -102,6 +102,46 @@ stories
       </Column>
     </Grid>
   ))
+  .add('Manual order', () => (
+    <Grid wrap>
+      <Column
+        className="slds-m-bottom--large slds-p-horizontal_small"
+        sizeOf="1-2"
+        order="1"
+        small-order="2"
+        medium-order="3"
+      >
+        <Box>One. Try adjusting the window width!</Box>
+      </Column>
+      <Column
+        className="slds-m-bottom--large slds-p-horizontal_small"
+        sizeOf="1-2"
+        order="2"
+        small-order="1"
+        medium-order="2"
+      >
+        <Box>Two. Responsive Reordering baby! Yeah!</Box>
+      </Column>
+      <Column
+        className="slds-m-bottom--large slds-p-horizontal_small"
+        sizeOf="1-2"
+        order="3"
+        small-order="4"
+        medium-order="1"
+      >
+        <Box>Three. I think that&apos;s pretty neat!</Box>
+      </Column>
+      <Column
+        className="slds-m-bottom--large slds-p-horizontal_small"
+        sizeOf="1-2"
+        order="4"
+        small-order="3"
+        medium-order="4"
+      >
+        <Box>Four. Don&apos;t you?</Box>
+      </Column>
+    </Grid>
+  ))
   .add('Containers', () => (
     <div>
       <Container


### PR DESCRIPTION
Add non-responsive `order` prop to reorder `Columns` in `Grid`. Responsive usage is similar to `sizeOf ` prop, e.g. `small-order="3"` or `medium-order="4"`. 