### PR TITLE
Fluid carousel layout

### DIFF
--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -11,7 +11,7 @@ class Carousel extends Component {
   }
 
   autoPlayId = null // eslint-disable-line react/sort-comp
-  autoPlayFlavors = ['icon-border-filled', 'icon-x-small'];
+  autoPlayFlavors = ['icon-border-filled', 'icon-x-small']
 
   componentWillMount() {
     const { autoPlayActive, children } = this.props;
@@ -80,11 +80,13 @@ class Carousel extends Component {
 
   updatePanels(panels) {
     const { activeIndex } = this.state;
+
     this.setState({
       activeIndex: Math.min(panels.length, activeIndex),
       panels: React.Children.map(panels, (panel, index) => (
         React.cloneElement(panel, {
           active: activeIndex === index,
+          onKeyboardInteraction: this.onKeyboardInteraction,
         })
       )),
     });
@@ -203,7 +205,7 @@ class Carousel extends Component {
     const translateX = `translateX(-${activeIndex * 100}%)`;
 
     return (
-      <div className={cx(sldsClasses)} onKeyDown={this.onKeyboardInteraction}>
+      <div className={cx(sldsClasses)}>
         <div className="slds-carousel__stage">
           {autoPlay && this.renderAutoPlay()}
           <div className="slds-carousel__panels" style={{ transform: translateX }}>

--- a/src/components/Carousel/CarouselPanel.js
+++ b/src/components/Carousel/CarouselPanel.js
@@ -5,20 +5,39 @@ import cx from 'classnames';
 const CarouselPanel = (props) => {
   const {
     active,
+    backgroundStyle,
     children,
     className,
     id,
     imageUrl,
+    onKeyboardInteraction,
     title,
     ...rest
   } = props;
 
   const sldsClasses = [
     'slds-carousel__panel',
-    className
+    className,
   ];
 
   const tabIndex = active ? 0 : -1;
+
+  const renderedImage = backgroundStyle
+    ? (
+      <div
+        alt={title}
+        className="slds-carousel__image"
+        style={{
+          ...backgroundStyle,
+          backgroundImage: `url('${imageUrl}')`,
+        }}
+      />
+    )
+    : (
+      <div className="slds-carousel__image">
+        <img src={imageUrl} alt={title} />
+      </div>
+    );
 
   return (
     <div
@@ -29,10 +48,12 @@ const CarouselPanel = (props) => {
       aria-hidden={active}
       aria-labelledby={`${id}-indicator`}
     >
-      <a className="slds-carousel__panel-action slds-text-link_reset" tabIndex={tabIndex}>
-        <div className="slds-carousel__image">
-          <img src={imageUrl} alt={title} />
-        </div>
+      <a
+        className="slds-carousel__panel-action slds-text-link_reset"
+        onKeyDown={onKeyboardInteraction}
+        tabIndex={tabIndex}
+      >
+        {renderedImage}
         <div className="slds-carousel__content">
           <h2 className="slds-carousel__content-title">{title}</h2>
           <p>{children}</p>
@@ -44,8 +65,10 @@ const CarouselPanel = (props) => {
 
 CarouselPanel.defaultProps = {
   active: false,
+  backgroundStyle: null,
   children: [],
   className: null,
+  onKeyboardInteraction: null,
 };
 
 CarouselPanel.propTypes = {
@@ -55,9 +78,15 @@ CarouselPanel.propTypes = {
   active: PropTypes.bool,
 
   /**
+   * renders the image as background image and adds the given style
+   */
+  backgroundStyle: PropTypes.object,
+
+  /**
    * list of carousel panels
    */
   children: PropTypes.node,
+
   /**
    * class name
    */
@@ -72,6 +101,11 @@ CarouselPanel.propTypes = {
    * url for the panel image
    */
   imageUrl: PropTypes.string.isRequired,
+
+  /**
+   * Callback for keyboard interaction on an active panel.
+   */
+  onKeyboardInteraction: PropTypes.func,
 
   /**
    * title text

--- a/src/components/Carousel/__tests__/Carousel.spec.js
+++ b/src/components/Carousel/__tests__/Carousel.spec.js
@@ -55,7 +55,7 @@ describe('<Carousel />', () => {
       { title: 'Title 2', children: 'Content 2' },
     ]);
 
-    mounted.simulate('keydown', { keyCode: 39 });
+    mounted.find('CarouselPanel').at(0).find('a').simulate('keydown', { keyCode: 39 });
 
     expect(mounted.find('CarouselPanel').at(0).prop('active'))
       .toBe(false);
@@ -69,8 +69,8 @@ describe('<Carousel />', () => {
       { title: 'Title 2', children: 'Content 2' },
     ]);
 
-    mounted.simulate('keydown', { keyCode: 39 });
-    mounted.simulate('keydown', { keyCode: 39 });
+    mounted.find('CarouselPanel').at(0).find('a').simulate('keydown', { keyCode: 39 });
+    mounted.find('CarouselPanel').at(1).find('a').simulate('keydown', { keyCode: 39 });
 
     expect(mounted.find('CarouselPanel').at(0).prop('active'))
       .toBe(true);


### PR DESCRIPTION
- This moves the keyboard event handler to the anchor which is supposed to receive the keyboard events
- Also, this adds a way to render the panel image as a background image, thus supporting custom styles with `background-size` and `background-position`