### PR TITLE
Prevent Tabs componentWillReceiveProps from always triggering

### DIFF
--- a/src/components/Tabs/ControlledTabs.js
+++ b/src/components/Tabs/ControlledTabs.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { isEqual } from 'lodash';
 import { getAriaLabel, getTabsClass } from './utils';
 import TabLink from './TabLink';
 
@@ -63,7 +64,10 @@ class ControlledTabs extends PureComponent {
   }
 
   componentWillReceiveProps({ children: nextChildren }) {
-    if (ControlledTabs.getPanelState(nextChildren) !== ControlledTabs.getPanelState(this.props.children)) {
+    const { positions: prevPositions } = this.state;
+    const nextPositions = ControlledTabs.getPanelState(nextChildren).positions;
+
+    if (!isEqual(prevPositions, nextPositions)) {
       this.setState(ControlledTabs.getPanelState(nextChildren));
     }
   }

--- a/src/components/Tabs/ControlledTabs.js
+++ b/src/components/Tabs/ControlledTabs.js
@@ -64,11 +64,14 @@ class ControlledTabs extends PureComponent {
   }
 
   componentWillReceiveProps({ children: nextChildren }) {
-    const { positions: prevPositions } = this.state;
-    const nextPositions = ControlledTabs.getPanelState(nextChildren).positions;
+    const nextChildrenArr = React.Children.toArray(nextChildren);
+    const prevChildrenArr = React.Children.toArray(this.children);
 
-    if (!isEqual(prevPositions, nextPositions)) {
-      this.setState(ControlledTabs.getPanelState(nextChildren));
+    const isEqualLength = nextChildrenArr.length !== prevChildrenArr.length;
+    const nextState = ControlledTabs.getPanelState(nextChildrenArr);
+
+    if (!isEqualLength || !isEqual(nextState.positions, this.state.positions)) {
+      this.setState(nextState);
     }
   }
 


### PR DESCRIPTION
@extronics I think you might run into the same with Carousel. Comparing react children always results in true