### PR TITLE
Improve focus handling in Modal

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -6,6 +6,14 @@ import ModalHeader from './ModalHeader';
 import { getContentId, getTitleId } from './utils';
 
 class Modal extends Component {
+  constructor(props) {
+    super(props);
+    this.focusTrapOptions = {
+      escapeDeactivates: false,
+      fallbackFocus: null,
+    };
+  }
+
   onClose = (evt) => {
     evt.stopPropagation();
     const { onClose } = this.props;
@@ -18,6 +26,10 @@ class Modal extends Component {
       evt.stopPropagation();
       this.onClose(evt);
     }
+  }
+
+  setRef = (ref) => {
+    this.focusTrapOptions.fallbackFocus = ref;
   }
 
   cloneWithProps = (child) => {
@@ -58,18 +70,22 @@ class Modal extends Component {
     );
 
     return (
-      <div>
+      <FocusTrap
+        active={open}
+        focusTrapOptions={this.focusTrapOptions}
+        onKeyUp={onClose ? this.onKeyUp : null}
+      >
         <section
           {...rest}
           className={sldsClasses}
-          onKeyUp={onClose ? this.onKeyUp : null}
+          ref={this.setRef}
           role={prompt ? 'alertdialog' : 'dialog'}
           tabIndex={-1}
           aria-modal="true"
           aria-describedby={contentId}
           aria-labelledby={titleId}
         >
-          <FocusTrap className="slds-modal__container" active={open}>
+          <div className="slds-modal__container">
             <ModalHeader
               id={titleId}
               onClose={onClose ? this.onClose : null}
@@ -78,15 +94,15 @@ class Modal extends Component {
               title={title}
             />
             {React.Children.map(children, this.cloneWithProps)}
-          </FocusTrap>
+          </div>
         </section>
         <div
-          className={cx(
+          className={cx([
             'slds-backdrop',
             { 'slds-backdrop_open': open }
-          )}
+          ])}
         />
-      </div>
+      </FocusTrap>
     );
   }
 }

--- a/src/components/Modal/ModalContent.js
+++ b/src/components/Modal/ModalContent.js
@@ -22,8 +22,6 @@ const ModalContent = ({
   </div>
 );
 
-ModalContent.displayName = 'ModalContent';
-
 ModalContent.defaultProps = {
   className: null,
   id: null,

--- a/src/components/Modal/__tests__/Modal.spec.js
+++ b/src/components/Modal/__tests__/Modal.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import FocusTrap from 'focus-trap-react';
 import Modal from '../Modal';
 import ModalContent from '../ModalContent';
 import ModalFooter from '../ModalFooter';
@@ -28,14 +29,14 @@ describe('<Modal />', () => {
     const mounted = getComponent();
     expect(mounted.find('.slds-modal').hasClass('slds-fade-in-open')).toBeFalsy();
     expect(mounted.find('.slds-backdrop').hasClass('slds-backdrop_open')).toBeFalsy();
-    expect(mounted.find('FocusTrap').prop('active')).toBeFalsy();
+    expect(mounted.find(FocusTrap).prop('active')).toBeFalsy();
   });
 
   it('renders as open', () => {
     const mounted = getComponent({ open: true });
     expect(mounted.find('.slds-modal').hasClass('slds-fade-in-open')).toBeTruthy();
     expect(mounted.find('.slds-backdrop').hasClass('slds-backdrop_open')).toBeTruthy();
-    expect(mounted.find('FocusTrap').prop('active')).toBeTruthy();
+    expect(mounted.find(FocusTrap).prop('active')).toBeTruthy();
   });
 
   it('renders with a different transitionStyle', () => {
@@ -64,7 +65,7 @@ describe('<Modal />', () => {
   it('closes the modal when esc is pressed', () => {
     const mockFn = jest.fn();
     const mounted = getComponent({ onClose: mockFn });
-    mounted.find('section').simulate('keyUp', { key: 'Escape', stopPropagation: jest.fn() });
+    mounted.find(FocusTrap).simulate('keyUp', { key: 'Escape', stopPropagation: jest.fn() });
     expect(mockFn).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
* Add fallbackFocus to prevent component to throw in rare cases
* Handle escape key when backdrop is focussed
* Move focusTrap to top-level to prevent text from not being selectable