### PR TITLE
Change ComboboxDropdownList children proptype to node

### DIFF
--- a/src/components/Combobox/ComboboxDropdownList.js
+++ b/src/components/Combobox/ComboboxDropdownList.js
@@ -30,7 +30,7 @@ ComboboxDropdownList.propTypes = {
   /**
    * list content
    */
-  children: PropTypes.arrayOf(PropTypes.element),
+  children: PropTypes.node,
   /**
    * sets the number of items being displayed
    */


### PR DESCRIPTION
The old proptype throws a wrong prop warning if only one element is passed as children.