### PR TITLE
Fix ClickOutside triggering ::selection pseudo selector

### DIFF
--- a/src/components/ClickOutside/ClickOutside.js
+++ b/src/components/ClickOutside/ClickOutside.js
@@ -70,13 +70,11 @@ export default class ClickOutside extends Component {
 
   registerEventListener() {
     const { useCapture } = this.props;
-
     document.addEventListener('click', this.handle, useCapture);
   }
 
   unregisterEventListener() {
     const { useCapture } = this.props;
-
     document.removeEventListener('click', this.handle, useCapture);
   }
 
@@ -100,7 +98,7 @@ export default class ClickOutside extends Component {
     } = this.props;
 
     return (
-      <div tabIndex="-1" onKeyUp={condition ? this.handleKeyUp : null} {...rest} ref={this.getContainer}>
+      <div onKeyUp={condition ? this.handleKeyUp : null} {...rest} ref={this.getContainer}>
         {children}
       </div>
     );

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -50,8 +50,9 @@ export class MenuRaw extends Component {
     const { open } = this.state;
     const rest = omit(this.props, ['button', 'defaultOpen', 'closeOnClickOutside']);
     const condition = closeOnClickOutside && open;
+
     return (
-      <ClickOutside onClickOutside={this.onClickOutside} condition={condition} >
+      <ClickOutside onClickOutside={this.onClickOutside} condition={condition}>
         <ControlledMenu
           {...rest}
           button={this.getButton()}


### PR DESCRIPTION
Applying `tabIndex=-1` here results in the `::selection` pseudo selector being triggered on the wrapped element if a click or keyboard event is fired inside.