### PR TITLE
Compatibility with latest LDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## 7.2.6
 
 * Fixed: `DataTable`: Added horizontal scrolling for table with fixed header
+* Changed: `ModalContent`: Added option to collapse padding
+* Changed: `MenuSubHeader`: Allow passing elements as children
+* Changed: Allow grid components to have arbitrary DOM elements as containers
+* Changed: `MediaObject`: Allow passing figureRenderers
+* Changed: `ComboboxDropdown`: Added `onInputLabelClick` handler
+* Changed: `ComboboxDropdown`: Allow to be empty
+* Changed: `ComboboxDropdownItems`: Added back `alwaysDisplay` option to icons
+* Changed: `ComboboxDropdownItems`: Allow React elements as children
+* Changed: Return early if `ComboboxDropdownList` does not have children
+* Changed: Added forwarding refs to Input, Button and Listbox children
+* Changed: Upgraded enzyme, jest & moment
 
 ## 7.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 8.0.0
+
+* Added: `Button` now supports new flavors `text-destructive` & `outline-brand`
+* Added: `ButtonGroup` now supports rendering as a `row`
+* Added: `DescriptiveProgressBar` allows adding more information to a `ProgressBar`
+* Added: `File` now supports rendering a loading `Spinner`
+* Added: `Grid` now allows to only apply `gutters` to direct children when `guttersDirect` is set
+* Added: `Input` now supports a `static` variant
+* Added: `ProgressBar` now supports rendering a `vertical` variant
+* Added: `ProgressRing` now supports the new `active-step` status which renders a blue ring
+* Added: `ProgressRing` now supports rendering a version that fills rather than drains
+* Added: `Spinner` now supports rendering `inline`
+* Added: `Spinner` can now wrap a `SpinnerContainer` when `container` is set to `true`
+* Added: `Tabs` now supports setting `size`
+* Added: `UserAvatar` and `EntityAvatar` supersede `Avatar` (which is now deprecated)
+* Added: `DataTable` now allows hiding the table header
+* Changed: Updated various components to accomodate changed LDS specs
+* Changed: `ProgressRing` renders as `fill` variant per default. Previous default was `drain`
+* Changed: `PageHeaders` have significantly changed in their internal structure
+
 ## 7.2.6
 
 * Fixed: `DataTable`: Added horizontal scrolling for table with fixed header

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-popper": "^1.0.0"
   },
   "devDependencies": {
-    "@salesforce-ux/design-system": "2.5.2",
+    "@salesforce-ux/design-system": "~2.7.4",
     "@storybook/addon-actions": "~3.2.16",
     "@storybook/addon-info": "~3.2.16",
     "@storybook/addon-knobs": "~3.2.16",

--- a/src/components/Accordion/AccordionSection.js
+++ b/src/components/Accordion/AccordionSection.js
@@ -27,7 +27,7 @@ const AccordionSection = (props) => {
         id={id}
       >
         <div className="slds-accordion__summary">
-          <h3 className="slds-text-heading_small slds-accordion__summary-heading">
+          <h3 className="slds-accordion__summary-heading">
             <Button
               sprite="utility"
               icon={isOpen ? 'chevrondown' : 'chevronright'}

--- a/src/components/Accordion/__tests__/Accordion.spec.js
+++ b/src/components/Accordion/__tests__/Accordion.spec.js
@@ -107,7 +107,7 @@ describe('<Accordion />', () => {
       .first()
       .find('h3')
       .first()
-      .hasClass('slds-text-heading_small slds-accordion__summary-heading')).toBeTruthy();
+      .hasClass('slds-accordion__summary-heading')).toBeTruthy();
   });
 
   it('applies className and rest-properties to Accordion', () => {

--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -19,52 +19,61 @@ const Alert = (props) => {
 
   const sldsClasses = [
     'slds-notify',
-    { 'slds-notify_toast': !!toast },
-    { 'slds-notify_alert': !toast },
-    { 'slds-theme_alert-texture': !toast },
+    { 'slds-notify_toast': toast },
+    { 'slds-notify_alert slds-theme_alert-texture': !toast },
     getThemeClass(theme),
     className,
   ];
 
-  let iconEl = null;
+  let iconEl;
+  let iconContainerClasses;
 
   if (React.isValidElement(icon)) {
     iconEl = React.cloneElement(icon, { size: toast ? 'small' : 'x-small' });
+
+    iconContainerClasses = [
+      'slds-icon_container',
+      { 'slds-m-right_small slds-no-flex slds-align-top': toast },
+      { 'slds-m-right_x-small': !toast },
+    ];
   }
 
-  return (
-    <div className="slds-notify_container">
-      <div {...rest} className={cx(sldsClasses)} role="alert">
-        {iconEl && (
-          <span className="slds-icon_container slds-m-right_small slds-no-flex slds-align-top">
-            {iconEl}
-            <span className="slds-assistive-text">{title}</span>
-          </span>
-        )}
-        <IconButton
-          flavor="inverse"
-          className="slds-notify__close"
-          onClick={onClickClose}
-          title="Close"
-        >
-          <ButtonIcon
-            sprite="utility"
-            icon="close"
-            size={toast ? 'large' : undefined}
-          />
-        </IconButton>
-        <span className="slds-assistive-text">{title}</span>
-        {toast ? <div className="slds-notify__content">{children}</div> : children }
-      </div>
+  const alert = (
+    <div {...rest} className={cx(sldsClasses)} role={toast ? 'status' : 'alert'}>
+      <span className="slds-assistive-text">{title}</span>
+      {iconEl && <span className={cx(iconContainerClasses)}>{iconEl}</span>}
+      {toast
+        ? <div className="slds-notify__content">{children}</div>
+        : children
+      }
+      {onClickClose && (
+        <div className="slds-notify__close">
+          <IconButton
+            flavor="inverse"
+            onClick={onClickClose}
+            title="Close"
+          >
+            <ButtonIcon
+              sprite="utility"
+              icon="close"
+              size={toast ? 'large' : null}
+            />
+          </IconButton>
+        </div>
+      )}
     </div>
   );
+
+  return toast
+    ? <div className="slds-notify_container slds-is-relative">{alert}</div>
+    : alert;
 };
 
 Alert.defaultProps = {
   className: null,
   icon: null,
   toast: false,
-  onClickClose: () => {},
+  onClickClose: null,
   theme: 'info',
 };
 
@@ -78,9 +87,9 @@ Alert.propTypes = {
    */
   className: PropTypes.string,
   /**
-  * IconSVG
+  * IconSVG element
   */
-  icon: PropTypes.node,
+  icon: PropTypes.element,
   /**
    * notification title (will be rendered as assistiveText)
    */

--- a/src/components/Alert/__tests__/Alert.spec.js
+++ b/src/components/Alert/__tests__/Alert.spec.js
@@ -1,42 +1,87 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import Alert from '../Alert';
+import { IconButton, ButtonIcon } from '../../Button';
+
+const sampleChild = <p>Foobar</p>;
+
+const getComponent = (props = {}) => shallow(
+  <Alert {...props} title="Foo">{sampleChild}</Alert>
+);
 
 describe('<Alert />', () => {
-  let mounted = null;
-  let props = {};
+  it('renders the correct markup', () => {
+    const mounted = getComponent();
+    const notification = mounted.find('.slds-notify');
 
-  const child = <p>Foobar</p>;
+    expect(notification.hasClass('slds-notify_alert')).toBeTruthy();
+    expect(notification.hasClass('slds-notify_toast')).toBeFalsy();
+    expect(notification.prop('role')).toEqual('alert');
+    expect(notification.find('.slds-notify > .slds-assistive-text').text()).toEqual('Foo');
+    expect(mounted.contains(sampleChild)).toBeTruthy();
+  });
 
-  beforeEach(() => {
-    props = {
-      title: 'foo',
+  it('renders and binds a close button', () => {
+    const expectButtonPresent = (cmp, truthy) => {
+      const expectation = cmp.find('.slds-notify__close').exists();
+      if (truthy) expect(expectation).toBeTruthy();
+      else expect(expectation).toBeFalsy();
     };
 
-    mounted = mount(<Alert {...props}>{child}</Alert>);
+    const mounted = getComponent();
+    expectButtonPresent(mounted, false);
+    const mockFn = jest.fn();
+    mounted.setProps({ onClickClose: mockFn });
+    expectButtonPresent(mounted, true);
+    const closeButton = mounted.find('.slds-notify__close').find(IconButton);
+    closeButton.simulate('click');
+    expect(closeButton.prop('size')).toBeNull();
+    expect(mockFn).toBeCalled();
   });
 
-  it('renders the correct markup', () => {
-    const container = mounted.find('.slds-notify_container');
-    const notification = container.find('.slds-notify');
-    expect(notification.find('button').length).toBe(1);
-    expect(notification.find('button > .slds-assistive-text').length).toBe(1);
-    expect(notification.find('button > .slds-assistive-text').length).toBe(1);
-    expect(notification.contains(child)).toBeTruthy();
+  it('renders an icon if set', () => {
+    const sampleIcon = <p>Sample</p>;
+    const mounted = getComponent({ icon: sampleIcon });
+    const iconContainer = mounted.find('.slds-icon_container');
+    const icon = iconContainer.find('p');
+    expect(iconContainer.hasClass('slds-m-right_x-small')).toBeTruthy();
+    expect(icon.exists()).toBeTruthy();
+    expect(icon.prop('size')).toEqual('x-small');
   });
 
-  it('renders large close icons for toasts', () => {
-    mounted.setProps({ toast: true });
-    expect(mounted.find('button svg').hasClass('slds-button__icon_large')).toBeTruthy();
+  it('renders as toast', () => {
+    const mockFn = jest.fn();
+    const sampleIcon = <p>Sample</p>;
+    const mounted = getComponent({
+      icon: sampleIcon,
+      onClickClose: mockFn,
+      toast: true,
+    });
 
-    mounted.setProps({ toast: false });
-    expect(mounted.find('button svg').hasClass('slds-button__icon_large')).toBeFalsy();
+    const notification = mounted.find('.slds-notify');
+    expect(notification.hasClass('slds-notify_toast')).toBeTruthy();
+    expect(notification.hasClass('slds-notify_alert')).toBeFalsy();
+    expect(notification.prop('role')).toEqual('status');
+    expect(mounted.find('.slds-notify_container').find('.slds-notify').exists()).toBeTruthy();
+    const iconContainer = mounted.find('.slds-icon_container');
+    const icon = iconContainer.find('p');
+    expect(iconContainer.hasClass('slds-m-right_small')).toBeTruthy();
+    expect(icon.prop('size')).toEqual('small');
+    expect(mounted.find('.slds-notify__close').find(ButtonIcon).prop('size')).toEqual('large');
   });
 
-  it('applies className and rest-properties', () => {
-    mounted.setProps({ className: 'foo', 'data-test': 'bar' });
-    expect(mounted.find('.slds-notify').hasClass('foo')).toBeTruthy();
-    expect(mounted.find('.slds-notify').prop('data-test')).toEqual('bar');
+  it('applies rest props, classname and theme', () => {
+    const mounted = getComponent({
+      'aria-hidden': true,
+      className: 'foo',
+      theme: 'info'
+    });
+
+    const notification = mounted.find('.slds-notify');
+    expect(notification.hasClass('slds-theme_info')).toBeTruthy();
+    expect(notification.hasClass('foo')).toBeTruthy();
+    expect(notification.prop('aria-hidden')).toBeTruthy();
   });
 });
+

--- a/src/components/Button/Base/Button.js
+++ b/src/components/Button/Base/Button.js
@@ -89,16 +89,18 @@ Button.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Can be either `neutral`, `brand`, `destructive`, `success` or `inverse`
+   * Can be either `neutral`, `brand`, `outline-brand`, `destructive`, `text-destructive`, `success` or `inverse`
    * Default to `neutral`, set to "none" or `null` explicitely to render a plain button
    */
   flavor: PropTypes.oneOf([
-    'none',
-    'neutral',
     'brand',
     'destructive',
+    'inverse',
+    'neutral',
+    'none',
+    'outline-brand',
     'success',
-    'inverse'
+    'text-destructive',
   ]),
   /**
    * Optional href, renders as `a` when set

--- a/src/components/Button/Base/StatefulButtonState.js
+++ b/src/components/Button/Base/StatefulButtonState.js
@@ -5,9 +5,9 @@ import ButtonIcon from './ButtonIcon';
 
 const renderStatefulButtonIcon = (icon, sprite) => (
   <ButtonIcon
-    className="slds-button__icon_stateful"
     position="left"
     icon={icon}
+    size="small"
     sprite={sprite}
   />
 );

--- a/src/components/Button/ButtonGroups/ButtonGroup.js
+++ b/src/components/Button/ButtonGroups/ButtonGroup.js
@@ -2,34 +2,46 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-const wrapLi = (el, i) => <li key={i}>{el}</li>;
-
 const ButtonGroup = (props) => {
   const {
     children,
     className,
     list,
+    row,
     ...rest
   } = props;
 
+  const wrapLi = (el, i) => (
+    <li className={row ? 'slds-button-group-item' : null} key={i}>{el}</li>
+  );
+
+  const isDivGroup = !list && !row;
+
   const sldsClasses = cx(
-    list ? 'slds-button-group-list' : 'slds-button-group',
+    { 'slds-button-group': isDivGroup },
+    { 'slds-button-group-list': list },
+    { 'slds-button-group-row': row },
     className
   );
 
-  const GroupEl = list ? 'ul' : 'div';
-  const childEls = list ? React.Children.map(children, wrapLi) : children;
+  const ButtonGroupEl = isDivGroup ? 'div' : 'ul';
+  const childEls = !isDivGroup ? React.Children.map(children, wrapLi) : children;
 
   return (
-    <GroupEl {...rest} className={cx(sldsClasses)} role="group">
+    <ButtonGroupEl
+      {...rest}
+      className={cx(sldsClasses)}
+      role={isDivGroup ? 'group' : null}
+    >
       {childEls}
-    </GroupEl>
+    </ButtonGroupEl>
   );
 };
 
 ButtonGroup.defaultProps = {
   className: null,
   list: false,
+  row: false,
 };
 
 ButtonGroup.propTypes = {
@@ -45,6 +57,10 @@ ButtonGroup.propTypes = {
    * Renders the button group as a list
    */
   list: PropTypes.bool,
+  /**
+   * Renders the button group as a row of separate buttons
+   */
+  row: PropTypes.bool,
 };
 
 export default ButtonGroup;

--- a/src/components/Button/ButtonGroups/__tests__/ButtonGroup.spec.js
+++ b/src/components/Button/ButtonGroups/__tests__/ButtonGroup.spec.js
@@ -19,9 +19,24 @@ describe('<ButtonGroup />', () => {
     expect(mounted.contains(sampleChild)).toBeTruthy();
   });
 
+  it('renders as div group by default', () => {
+    const mounted = getComponent();
+    expect(mounted.find('div.slds-button-group').prop('role')).toEqual('group');
+  });
+
   it('renders as list', () => {
     const mounted = getComponent({ list: true });
-    expect(mounted.find('ul').hasClass('slds-button-group-list')).toBeTruthy();
-    expect(mounted.find('li').contains(sampleChild)).toBeTruthy();
+    const wrapper = mounted.find('ul.slds-button-group-list');
+    expect(wrapper.prop('role')).toBeNull();
+    expect(wrapper.find('li').hasClass('slds-button-group-item')).toBeFalsy();
+    expect(wrapper.find('li').contains(sampleChild)).toBeTruthy();
+  });
+
+  it('renders as row', () => {
+    const mounted = getComponent({ row: true });
+    const wrapper = mounted.find('ul.slds-button-group-row');
+    expect(wrapper.prop('role')).toBeNull();
+    expect(wrapper.find('li').hasClass('slds-button-group-item')).toBeTruthy();
+    expect(wrapper.find('li').contains(sampleChild)).toBeTruthy();
   });
 });

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -88,7 +88,7 @@ Card.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * footer in the bottom right corner
+   * footer, rendered on the bottom of the card
    */
   footer: PropTypes.node,
   /**

--- a/src/components/Carousel/CarouselPanel.js
+++ b/src/components/Carousel/CarouselPanel.js
@@ -45,7 +45,7 @@ const CarouselPanel = (props) => {
       className={cx(sldsClasses)}
       id={id}
       role="tabpanel"
-      aria-hidden={active}
+      aria-hidden={!active}
       aria-labelledby={`${id}-indicator`}
     >
       <a

--- a/src/components/Combobox/ComboboxDropdownListItem.js
+++ b/src/components/Combobox/ComboboxDropdownListItem.js
@@ -33,6 +33,9 @@ const ComboboxDropdownListItem = (props) => {
     selected,
   } = props;
 
+  const iconEl = renderIcon(icon, selected);
+  const isIconOption = iconEl || (icon && !selected);
+
   const sldsClasses = [
     'slds-listbox__item',
     { [className]: !isHeader },
@@ -40,7 +43,8 @@ const ComboboxDropdownListItem = (props) => {
 
   const itemClasses = [
     'slds-listbox__option',
-    'slds-listbox__option_plain',
+    { 'slds-listbox__option_plain': !isIconOption },
+    { 'slds-listbox__option_icon': isIconOption },
     { 'slds-is-selected': selected },
   ];
 
@@ -49,7 +53,7 @@ const ComboboxDropdownListItem = (props) => {
       <MediaObject
         center
         className={cx(itemClasses)}
-        figureLeft={renderIcon(icon, selected)}
+        figureLeft={iconEl}
         id={id}
         onClick={isHeader ? undefined : onClick}
         role={isHeader ? 'presentation' : 'option'}

--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -164,11 +164,13 @@ class DataTable extends Component {
   }
 
   renderHead() {
-    const { fixedHeader } = this.props;
+    const { fixedHeader, variation } = this.props;
     const { columns, id, sortBy, sortDirection } = this.state;
 
+    const hasHiddenHeader = !fixedHeader && variation.includes('header-hidden');
+
     return (
-      <thead>
+      <thead className={hasHiddenHeader ? 'slds-assistive-text' : null}>
         <tr>
           {columns.map(({ headRenderer, ...restProps }) =>
             headRenderer({

--- a/src/components/File/File.js
+++ b/src/components/File/File.js
@@ -29,7 +29,8 @@ const File = (props) => {
   const sldsClasses = [
     'slds-file',
     'slds-file_card',
-    { 'slds-file_center-icon': isLoading && hideTitle },
+    { 'slds-has-title': !hideTitle },
+    { 'slds-file_loading': isLoading },
   ];
 
   const mediaClasses = [

--- a/src/components/File/FileMedia.js
+++ b/src/components/File/FileMedia.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from '../..';
+import { Icon } from '../Icon';
+import { Spinner } from '../Spinner';
 
 const FileMedia = ({
   fileType,
@@ -8,18 +9,7 @@ const FileMedia = ({
   isLoading,
   title,
 }) => {
-  if (isLoading) {
-    return (
-      <Icon
-        className="slds-file__icon"
-        sprite="utility"
-        icon="image"
-        size="large"
-        svgClassName="slds-file__loading-icon"
-        title={title}
-      />
-    );
-  }
+  if (isLoading) return <Spinner size="medium" />;
 
   if (image && image.src) return <img src={image.src} alt={image.alt || title} />;
 

--- a/src/components/File/__tests__/File.spec.js
+++ b/src/components/File/__tests__/File.spec.js
@@ -10,14 +10,26 @@ const getComponent = (props = {}) => shallow(<File title="foo" {...props} />);
 describe('<File />', () => {
   it('renders a placeholder when loading', () => {
     const mounted = getComponent({ hideTitle: true, isLoading: true });
-    expect(mounted.find('.slds-file').hasClass('slds-file_center-icon')).toBeTruthy();
+    expect(mounted.find('.slds-file').hasClass('slds-file_loading')).toBeTruthy();
   });
 
   it('renders no caption if hideTitle is true', () => {
+    const expectTitle = (cmp, isVisible) => {
+      const expectations = [
+        expect(cmp.find('.slds-file').hasClass('slds-has-title')),
+        expect(cmp.find(FileCaption).exists())
+      ];
+
+      expectations.forEach((expectation) => {
+        if (isVisible) expectation.toBeTruthy();
+        else expectation.toBeFalsy();
+      });
+    };
+
     const mounted = getComponent();
-    expect(mounted.find(FileCaption).exists()).toBeTruthy();
+    expectTitle(mounted, true);
     mounted.setProps({ hideTitle: true });
-    expect(mounted.find(FileCaption).exists()).toBeFalsy();
+    expectTitle(mounted, false);
   });
 
   it('renders an external icon', () => {

--- a/src/components/File/__tests__/FileMedia.spec.js
+++ b/src/components/File/__tests__/FileMedia.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { Icon } from '../../../';
 import FileMedia from '../FileMedia';
+import { Spinner } from '../../Spinner';
 
 const getComponent = (props = {}) => shallow(
   <FileMedia
@@ -27,14 +28,8 @@ describe('<FileMedia />', () => {
 
   it('renders a loading indicator if isLoading is set', () => {
     const mounted = getComponent({ isLoading: true });
-    const $icon = mounted.find(Icon);
-
-    expect($icon.exists()).toBeTruthy();
-    expect($icon.props()).toMatchObject({
-      icon: 'image',
-      svgClassName: 'slds-file__loading-icon',
-      title: 'bar',
-    });
+    const spinner = mounted.find(Spinner);
+    expect(spinner.exists()).toBeTruthy();
   });
 
   it('renders an image if passed', () => {

--- a/src/components/Form/FormElement.js
+++ b/src/components/Form/FormElement.js
@@ -3,12 +3,21 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 const FormElement = (props) => {
-  const { children, className, error, required, fieldset, ...rest } = props;
+  const {
+    children,
+    className,
+    error,
+    fieldset,
+    isStatic,
+    required,
+    ...rest
+  } = props;
 
   const sldsClasses = [
     'slds-form-element',
     { 'slds-has-error': !!error },
     { 'slds-is-required': required },
+    { 'slds-form-element_readonly': isStatic },
     className
   ];
 
@@ -21,6 +30,7 @@ FormElement.defaultProps = {
   className: null,
   error: null,
   fieldset: false,
+  isStatic: false,
   required: false,
 };
 
@@ -41,6 +51,10 @@ FormElement.propTypes = {
    * renders as a fieldset instead
    */
   fieldset: PropTypes.bool,
+  /**
+   * Renders in a static, "view" mode
+   */
+  isStatic: PropTypes.bool,
   /**
    * adds required-attribute to the form element
    */

--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -18,6 +18,7 @@ const Input = React.forwardRef((props, ref) => {
     iconLeft,
     iconRight,
     id,
+    isStatic,
     label,
     placeholder,
     readOnly,
@@ -31,33 +32,38 @@ const Input = React.forwardRef((props, ref) => {
   const hasIconRight = !!iconRight || !!showSpinner;
 
   return (
-    <FormElement required={required} error={error}>
+    <FormElement isStatic={isStatic} required={required} error={error}>
       <FormElementLabel
         hideLabel={hideLabel}
         id={id}
         label={label}
+        readOnly={isStatic}
         required={required}
       />
       <FormElementControl
         hasIconLeft={hasIconLeft}
         hasIconRight={hasIconRight}
       >
-        <InputRaw
-          error={error}
-          errorIcon={errorIcon}
-          hideErrorMessage={hideErrorMessage}
-          iconLeft={iconLeft}
-          iconRight={iconRight}
-          id={id}
-          label={label}
-          placeholder={placeholder}
-          readOnly={readOnly}
-          ref={ref}
-          required={required}
-          showSpinner={showSpinner}
-          value={value}
-          {...rest}
-        />
+        {!isStatic ? (
+          <InputRaw
+            error={error}
+            errorIcon={errorIcon}
+            hideErrorMessage={hideErrorMessage}
+            iconLeft={iconLeft}
+            iconRight={iconRight}
+            id={id}
+            label={label}
+            placeholder={placeholder}
+            readOnly={readOnly}
+            ref={ref}
+            required={required}
+            showSpinner={showSpinner}
+            value={value}
+            {...rest}
+          />
+        ) : (
+          <div className="slds-form-element__static">{value}</div>
+        )}
       </FormElementControl>
       {!hideErrorMessage && <FormElementError error={error} id={id} />}
     </FormElement>
@@ -135,6 +141,10 @@ Input.propTypes = {
    */
   id: PropTypes.string.isRequired,
   /**
+   * Renders in a static, "view" mode
+   */
+  isStatic: PropTypes.bool,
+  /**
    * label for the input
    */
   label: PropTypes.oneOfType([
@@ -158,7 +168,7 @@ Input.propTypes = {
    */
   placeholder: PropTypes.string,
   /**
-   * makes Input readOnly
+   * Renders a read-only input element
    */
   readOnly: PropTypes.bool,
   /**

--- a/src/components/Form/__tests__/FormElement.spec.js
+++ b/src/components/Form/__tests__/FormElement.spec.js
@@ -31,6 +31,11 @@ describe('<FormElement />', () => {
     expect(mounted.find('fieldset.slds-form-element').length).toBe(1);
   });
 
+  it('renders a static version', () => {
+    mounted.setProps({ isStatic: true });
+    expect(mounted.find('.slds-form-element').hasClass('slds-form-element_readonly')).toBeTruthy();
+  });
+
   it('applies className and rest-properties', () => {
     mounted.setProps({ className: 'foo', 'data-test': 'bar' });
     expect(mounted.find('.slds-form-element').hasClass('foo')).toBeTruthy();

--- a/src/components/Form/__tests__/Input.spec.js
+++ b/src/components/Form/__tests__/Input.spec.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import { getUniqueHash } from '../../../utils';
 import Input from '../Input';
+import { FormElementLabel } from '..';
 
 describe('<Input />', () => {
   let props = {};
@@ -115,6 +116,18 @@ describe('<Input />', () => {
   it('renders disabled', () => {
     mounted.setProps({ disabled: true });
     expect(mounted.find('input').props().disabled).toBeTruthy();
+  });
+
+  it('renders required', () => {
+    mounted.setProps({ required: true });
+    expect(mounted.find('input').props().required).toBeTruthy();
+  });
+
+  it('renders as static output', () => {
+    mounted.setProps({ isStatic: true });
+    expect(mounted.find('input').exists()).toBeFalsy();
+    expect(mounted.find('.slds-form-element__static').exists()).toBeTruthy();
+    expect(mounted.find(FormElementLabel).prop('readOnly')).toBeTruthy();
   });
 
   it('renders errorIcon if set', () => {

--- a/src/components/Grid/Grid.js
+++ b/src/components/Grid/Grid.js
@@ -22,6 +22,7 @@ const Grid = (props) => {
     className,
     flavor,
     gutters,
+    guttersDirect,
     pullPadding,
     verticalAlign,
     wrap,
@@ -40,12 +41,12 @@ const Grid = (props) => {
     className,
   ];
 
-  if (gutters === true) {
-    sldsClasses.push('slds-gutters');
-  }
+  const guttersBaseClass = guttersDirect ? 'slds-gutters_direct' : 'slds-gutters';
 
-  if (gutters && gutters !== true) {
-    sldsClasses.push(`slds-gutters_${gutters}`);
+  if (gutters === true || (guttersDirect === true && gutters === false)) {
+    sldsClasses.push(guttersBaseClass);
+  } else if (gutters && gutters !== true) {
+    sldsClasses.push(`${guttersBaseClass}${guttersDirect ? '-' : '_'}${gutters}`);
   }
 
   return <El {...rest} className={cx(sldsClasses)}>{children}</El>;
@@ -57,6 +58,7 @@ Grid.defaultProps = {
   children: null,
   className: null,
   gutters: null,
+  guttersDirect: false,
   flavor: [],
   pullPadding: null,
   verticalAlign: null,
@@ -97,6 +99,10 @@ Grid.propTypes = {
    * Can either be true or any valid slds size string (xxx-small to xx-large)
    */
   gutters: PropTypes.oneOf([true, false, ...gutterSizes]),
+  /**
+   * When true, gutters will only be applied to direct children. Use in combination with `gutters`
+   */
+  guttersDirect: PropTypes.bool,
   /**
    * Controls how columns are aligned vertically.
    * Can either either: center, end, space

--- a/src/components/Grid/__tests__/Grid.spec.js
+++ b/src/components/Grid/__tests__/Grid.spec.js
@@ -35,6 +35,26 @@ describe('<Grid />', () => {
     expect(mounted.find('.slds-grid').hasClass('slds-wrap')).toBeTruthy();
   });
 
+  it('applies gutters when set to true', () => {
+    mounted.setProps({ gutters: true });
+    expect(mounted.find('.slds-grid').hasClass('slds-gutters')).toBeTruthy();
+  });
+
+  it('applies gutters when set to size', () => {
+    mounted.setProps({ gutters: 'small' });
+    expect(mounted.find('.slds-grid').hasClass('slds-gutters_small')).toBeTruthy();
+  });
+
+  it('applies direct gutters when set to true', () => {
+    mounted.setProps({ gutters: true, guttersDirect: true });
+    expect(mounted.find('.slds-grid').hasClass('slds-gutters_direct')).toBeTruthy();
+  });
+
+  it('applies direct gutters when set to string', () => {
+    mounted.setProps({ gutters: 'small', guttersDirect: true });
+    expect(mounted.find('.slds-grid').hasClass('slds-gutters_direct-small')).toBeTruthy();
+  });
+
   it('renders as arbitrary DOM node', () => {
     mounted.setProps({ as: 'footer' });
     expect(mounted.find('footer.slds-grid').exists()).toBeTruthy();

--- a/src/components/Images/Avatar.js
+++ b/src/components/Images/Avatar.js
@@ -1,10 +1,237 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import {
+  isString,
+  startCase,
+  upperCase,
+  words,
+} from 'lodash-es';
+import { Icon } from '../Icon';
 
-const Avatar = (props) => {
-  const { alt, circle, className, src, size, title, ...rest } = props;
+export const BaseAvatar = ({
+  className,
+  image,
+  round,
+  size,
+  renderFallback,
+  ...rest
+}) => (
+  <span
+    {...rest}
+    className={cx([
+      'slds-avatar',
+      { 'slds-avatar_circle': round },
+      { [`slds-avatar_${size}`]: size },
+      className,
+    ])}
+  >
+    {image || renderFallback()}
+  </span>
+);
 
+BaseAvatar.defaultProps = {
+  className: null,
+  image: null,
+  renderFallback: () => null,
+  round: false,
+  size: null,
+};
+
+BaseAvatar.propTypes = {
+  className: PropTypes.string,
+  image: PropTypes.element,
+  renderFallback: PropTypes.func,
+  round: PropTypes.bool,
+  size: PropTypes.oneOf(['x-small', 'small', 'medium', 'large']),
+};
+
+export const getInitials = (str = '') => {
+  if (!isString(str) || str.length === 0) return '';
+  const strWords = words(str);
+  const [first, second] = strWords;
+  if (!first) return '';
+  if (!second) return startCase(first.substring(0, 2));
+  return upperCase(`${first[0]}${second[0]}`);
+};
+
+export const EntityAvatar = ({
+  displayType,
+  icon: { icon, sprite },
+  name,
+  ...rest
+}) => {
+  const fallbackRenderer = displayType === 'icon'
+    ? () => <Icon icon={icon} sprite={sprite} title={name} />
+    : () => (
+      <abbr className={cx(['slds-avatar__initials', `slds-icon-${sprite}-${icon}`])} title={name}>
+        {getInitials(name)}
+      </abbr>
+    );
+
+  return <BaseAvatar {...rest} image={null} renderFallback={fallbackRenderer} />;
+};
+
+EntityAvatar.defaultProps = {
+  className: null,
+  displayType: 'icon',
+  round: false,
+  size: null,
+  title: null,
+};
+
+EntityAvatar.propTypes = {
+  /**
+   * Additional classnames
+   */
+  className: PropTypes.string,
+  /**
+   * Display Types:
+   * `icon`: icon set via `icon`
+   * `initials`: initials (computed from `name`) in `icon` coloring
+   */
+  displayType: PropTypes.oneOf(['icon', 'initials']),
+  /**
+   * Combination of icon and sprite corresponding to the entity type
+   */
+  icon: PropTypes.shape({
+    sprite: PropTypes.string.isRequired,
+    icon: PropTypes.string.isRequired,
+  }).isRequired,
+  /**
+   * Entity name
+   */
+  name: PropTypes.string.isRequired,
+  /**
+   * Avatar size
+   */
+  size: PropTypes.oneOf(['x-small', 'small', 'medium', 'large']),
+  /**
+   * `title` attribute, defaults to the value of `name` if not set
+   */
+  title: PropTypes.string,
+};
+
+export const UserAvatar = ({
+  className,
+  fallbackType,
+  imageSrc,
+  name,
+  round,
+  title,
+  ...rest
+}) => {
+  const tooltip = title || name;
+
+  if (imageSrc) {
+    return (
+      <BaseAvatar
+        {...rest}
+        className={className}
+        round={round}
+        image={<img src={imageSrc} alt={name} title={tooltip} />}
+      />
+    );
+  }
+
+  const sldsClasses = [
+    { 'slds-avatar_profile-image-large': fallbackType === 'profile-image' },
+    { 'slds-avatar_group-image-large': fallbackType === 'group-image' },
+    className,
+  ];
+
+  const isCssImageFallback = fallbackType === 'profile-image' || fallbackType === 'group-image';
+
+  let fallbackRenderer;
+
+  if (isCssImageFallback) {
+    fallbackRenderer = () => <span className="slds-assistive-text">{name}</span>;
+  } else if (fallbackType === 'icon') {
+    fallbackRenderer = () => <Icon sprite="standard" icon="user" title={tooltip} />;
+  } else {
+    const classes = [
+      'slds-avatar__initials',
+      { 'slds-icon-standard-user': fallbackType === 'initials' },
+      { 'slds-avatar__initials_inverse': fallbackType === 'initials-inverse' }
+    ];
+
+    fallbackRenderer = () => <abbr className={cx(classes)} title={tooltip}>{getInitials(name)}</abbr>;
+  }
+
+  return (
+    <BaseAvatar
+      {...rest}
+      className={cx(sldsClasses)}
+      round={round || !isCssImageFallback}
+      renderFallback={fallbackRenderer}
+      title={isCssImageFallback ? tooltip : null}
+    />
+  );
+};
+
+UserAvatar.defaultProps = {
+  className: null,
+  fallbackType: 'icon',
+  imageSrc: null,
+  round: false,
+  size: null,
+  title: null,
+};
+
+UserAvatar.propTypes = {
+  /**
+   * Additional classnames
+   */
+  className: PropTypes.string,
+  /**
+   * Fallback Types:
+   * `icon`: icon of the User object
+   * `initials`: initials (computed from `name`) in User object standard coloring
+   * `initials-inverse`: initials in inverse coloring
+   * `profile-image`: LDS profile image placeholder
+   * `group-image`: LDS group image placeholder
+   */
+  fallbackType: PropTypes.oneOf([
+    'icon',
+    'initials',
+    'initials-inverse',
+    'profile-image',
+    'group-image',
+
+  ]),
+  /**
+   * `src` attribute of the avatar image. If not set, a fallback of `fallbackType` will be rendered
+   */
+  imageSrc: PropTypes.string,
+  /**
+   * User Name or identifier
+   */
+  name: PropTypes.string.isRequired,
+  /**
+   * Renders as a round image / fallback
+   */
+  round: PropTypes.bool,
+  /**
+   * Avatar size
+   */
+  size: PropTypes.oneOf(['x-small', 'small', 'medium', 'large']),
+  /**
+   * `title` attribute, defaults to the value of `name` if not set
+   */
+  title: PropTypes.string,
+};
+
+// Deprecated
+export const Avatar = (props) => {
+  const {
+    alt,
+    circle,
+    className,
+    src,
+    size,
+    title,
+    ...rest
+  } = props;
   const sldsClasses = [
     'slds-avatar',
     { [`slds-avatar_${size}`]: !!size },
@@ -20,6 +247,7 @@ const Avatar = (props) => {
   );
 };
 
+// Deprecated
 Avatar.defaultProps = {
   alt: null,
   circle: false,
@@ -29,6 +257,7 @@ Avatar.defaultProps = {
   title: null,
 };
 
+// Deprecated
 Avatar.propTypes = {
   /**
    * img alt
@@ -55,5 +284,3 @@ Avatar.propTypes = {
    */
   title: PropTypes.string,
 };
-
-export default Avatar;

--- a/src/components/Images/__tests__/avatar.spec.js
+++ b/src/components/Images/__tests__/avatar.spec.js
@@ -1,8 +1,157 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
-import Avatar from '../Avatar';
+import {
+  Avatar,
+  BaseAvatar,
+  EntityAvatar,
+  UserAvatar,
+  getInitials,
+} from '../Avatar';
+import { Icon } from '../../Icon';
+
+describe('getInitials()', () => {
+  it('returns an empty string when passed an empty string or a non-string argument', () => {
+    expect(getInitials({})).toEqual('');
+    expect(getInitials(null)).toEqual('');
+    expect(getInitials('')).toEqual('');
+  });
+
+  it('returns an empty string when passed a string without words', () => {
+    expect(getInitials(', ? !')).toEqual('');
+  });
+
+  it('returns uppercased initials when two words or more are passed', () => {
+    expect(getInitials('John Doe')).toEqual('JD');
+    expect(getInitials('JohnDoe')).toEqual('JD');
+    expect(getInitials('John Doe Jr.')).toEqual('JD');
+  });
+
+  it('returns titleCased initials when one word is passed', () => {
+    expect(getInitials('John')).toEqual('Jo');
+  });
+});
+
+describe('<BaseAvatar />', () => {
+  const sampleChild = <p>Sample</p>;
+
+  const getComponent = (props = {}) => shallow(
+    <BaseAvatar {...props} renderFallback={() => sampleChild} />
+  );
+
+  it('renders an image if present', () => {
+    const mounted = getComponent({ image: sampleChild });
+    expect(mounted.find('.slds-avatar').contains(sampleChild)).toBeTruthy();
+  });
+
+  it('renders a fallback if not', () => {
+    const mounted = getComponent();
+    expect(mounted.find('.slds-avatar').contains(sampleChild)).toBeTruthy();
+  });
+
+  it('renders different size variants', () => {
+    const mounted = getComponent({ size: 'large' });
+    expect(mounted.find('.slds-avatar').hasClass('slds-avatar_large')).toBeTruthy();
+  });
+
+  it('renders a rounded variant', () => {
+    const mounted = getComponent({ round: true });
+    expect(mounted.find('.slds-avatar').hasClass('slds-avatar_circle')).toBeTruthy();
+  });
+
+  it('applies rest props and classnames to span', () => {
+    const mounted = getComponent({ className: 'foo', 'aria-hidden': true });
+    const avatar = mounted.find('.slds-avatar');
+    expect(avatar.hasClass('foo')).toBeTruthy();
+    expect(avatar.prop('aria-hidden')).toBeTruthy();
+  });
+});
+
+describe('<EntityAvatar />', () => {
+  const getComponent = (props = {}) => mount(
+    <EntityAvatar
+      name="Account"
+      icon={{ icon: 'account', sprite: 'standard' }}
+      {...props}
+    />
+  );
+
+  it('renders an icon by default', () => {
+    const mounted = getComponent();
+    expect(mounted.find(Icon).prop('icon')).toEqual('account');
+  });
+
+  it('renders initials', () => {
+    const mounted = getComponent({ displayType: 'initials' });
+    expect(mounted.find('abbr').hasClass('slds-avatar__initials')).toBeTruthy();
+  });
+
+  it('passes props to BaseAvatar', () => {
+    const mounted = getComponent({ className: 'foo', round: true });
+    const baseAvatar = mounted.find(BaseAvatar);
+    expect(baseAvatar.prop('image')).toBeNull();
+    expect(baseAvatar.prop('className')).toEqual('foo');
+    expect(baseAvatar.prop('round')).toBeTruthy();
+  });
+});
+
+describe('<UserAvatar />', () => {
+  const getComponent = (props = {}) => mount(
+    <UserAvatar name="John Doe" {...props} />
+  );
+
+  it('renders an image when imageSrc is set', () => {
+    const mounted = getComponent({ imageSrc: 'foo' });
+    expect(mounted.find('img').exists()).toBeTruthy();
+  });
+
+  it('renders css image fallbacks', () => {
+    const expectClass = (cmp, className) => {
+      const avatar = cmp.find('.slds-avatar');
+      expect(avatar.hasClass(className)).toBeTruthy();
+    };
+
+    const mounted = getComponent({ fallbackType: 'profile-image' });
+    expect(mounted.find('.slds-avatar').prop('title')).toEqual('John Doe');
+    expectClass(mounted, 'slds-avatar_profile-image-large');
+    mounted.setProps({ fallbackType: 'group-image' });
+    expectClass(mounted, 'slds-avatar_group-image-large');
+  });
+
+  it('renders an icon fallback', () => {
+    const mounted = getComponent({ fallbackType: 'icon', round: false });
+    expect(mounted.find(BaseAvatar).prop('round')).toBeTruthy();
+    const icon = mounted.find(Icon);
+    expect(icon.prop('icon')).toEqual('user');
+    expect(icon.prop('title')).toEqual('John Doe');
+  });
+
+  it('renders initials fallbacks', () => {
+    const expectClass = (cmp, className) => {
+      expect(cmp.find('.slds-avatar__initials').hasClass(className)).toBeTruthy();
+    };
+    const mounted = getComponent({ fallbackType: 'initials', round: false });
+    expect(mounted.find(BaseAvatar).prop('round')).toBeTruthy();
+    expectClass(mounted, 'slds-icon-standard-user');
+    mounted.setProps({ fallbackType: 'initials-inverse' });
+    expectClass(mounted, 'slds-avatar__initials_inverse');
+  });
+
+
+  it('allows to set title, falls back to name', () => {
+    const expectTitle = (cmp, title) => {
+      expect(cmp.find('img').prop('title')).toEqual(title);
+    };
+
+    const mounted = getComponent({ imageSrc: 'foo' });
+    expectTitle(mounted, 'John Doe');
+    mounted.setProps({ title: 'foo' });
+    expectTitle(mounted, 'foo');
+  });
+
+  it('passes props to BaseAvatar', () => {});
+});
 
 describe('<Avatar />', () => {
   let mounted = null;

--- a/src/components/Images/index.js
+++ b/src/components/Images/index.js
@@ -1,3 +1,2 @@
-import Avatar from './Avatar';
+export { EntityAvatar, UserAvatar, Avatar } from './Avatar';
 
-export { Avatar };

--- a/src/components/Menu/ControlledMenu.js
+++ b/src/components/Menu/ControlledMenu.js
@@ -50,7 +50,18 @@ const propTypes = {
   /**
    * position relative to the menu button
    */
-  position: PropTypes.oneOf(['top-left', 'top', 'top-right', 'bottom-left', 'bottom', 'bottom-right']),
+  position: PropTypes.oneOf([
+    'top-left',
+    'top-left-corner',
+    'top',
+    'top-right',
+    'top-right-corner',
+    'bottom-left',
+    'bottom-left-corner',
+    'bottom',
+    'bottom-right',
+    'bottom-right-corner',
+  ]),
   /**
    * render the dropdown even when it is closed
    */
@@ -141,8 +152,8 @@ class ControlledMenu extends Component {
     const dropdownClasses = [
       'slds-dropdown',
       { [`slds-dropdown_${size}`]: size },
-      { 'slds-dropdown_left': position.endsWith('left') },
-      { 'slds-dropdown_right': position.endsWith('right') },
+      { 'slds-dropdown_left': position.includes('left') },
+      { 'slds-dropdown_right': position.includes('right') },
       { 'slds-dropdown_bottom': position.startsWith('bottom') },
       { [`slds-nubbin_${position}`]: nubbin },
       className,

--- a/src/components/PageHeader/ObjectHome.js
+++ b/src/components/PageHeader/ObjectHome.js
@@ -1,60 +1,69 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import omit from 'lodash-es/omit';
 
 import {
   ClickOutside,
-  Column,
-  Grid,
   ControlledMenu,
   IconButton
 } from '../../';
-
-// https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types#is-it-safe
-const propTypes = {
-  /**
-   * bottom Buttons or ButtonGroup(s)
-   */
-  bottomButtons: PropTypes.node,
-  /**
-   * class name
-   */
-  className: PropTypes.string,
-  /**
-   * info that is displayed below the title
-   */
-  info: PropTypes.string,
-  /**
-   * Whether the menu closes automatically on an outside click
-   */
-  closeOnClickOutside: PropTypes.bool,
-  /**
-   * record type header above the title
-   */
-  recordType: PropTypes.string.isRequired,
-  /**
-   * title
-   */
-  title: PropTypes.string.isRequired,
-  /**
-   * dropdown header menu that also get's triggered when a user clicks on the
-   * title headline. Must be one or more instances of MenuItem/MenuSubHeader
-   */
-  titleMenu: PropTypes.node,
-  /**
-   * top Buttons or ButtonGroup(s)
-   */
-  topButtons: PropTypes.node,
-};
+import { MediaObject } from '../MediaObject';
+import { Icon } from '../Icon';
 
 class ObjectHome extends Component {
-  static propTypes = propTypes;
+  static propTypes = {
+    /**
+     * bottom Buttons or ButtonGroup(s)
+     */
+    bottomButtons: PropTypes.node,
+    /**
+     * Additional PageHeader rows
+     */
+    children: PropTypes.node,
+    /**
+     * class name
+     */
+    className: PropTypes.string,
+    /**
+     * Whether the menu closes automatically on an outside click
+     */
+    closeOnClickOutside: PropTypes.bool,
+    /**
+     * icon and sprite
+     */
+    icon: PropTypes.shape({
+      sprite: PropTypes.string.isRequired,
+      icon: PropTypes.string.isRequired,
+    }),
+    /**
+     * info that is displayed below the title
+     */
+    info: PropTypes.string,
+    /**
+     * record type header above the title
+     */
+    recordType: PropTypes.string.isRequired,
+    /**
+     * title
+     */
+    title: PropTypes.string.isRequired,
+    /**
+     * dropdown header menu that also get's triggered when a user clicks on the
+     * title headline. Must be one or more instances of MenuItem/MenuSubHeader
+     */
+    titleMenu: PropTypes.node,
+    /**
+     * top Buttons or ButtonGroup(s)
+     */
+    topButtons: PropTypes.node,
+  };
 
   static defaultProps = {
     bottomButtons: null,
+    children: null,
     className: null,
     closeOnClickOutside: false,
+    icon: null,
     info: null,
     titleMenu: null,
     topButtons: null,
@@ -78,72 +87,103 @@ class ObjectHome extends Component {
   render() {
     const {
       bottomButtons,
+      children,
       className,
       closeOnClickOutside,
+      icon,
       info,
       recordType,
       title,
       titleMenu,
       topButtons,
+      ...rest
     } = this.props;
     const { menuIsOpen } = this.state;
 
-    const rest = omit(this.props, Object.keys(propTypes));
-
-    const sldsClasses = [
-      'slds-page-header',
-      className,
-    ];
+    const sldsClasses = ['slds-page-header', className];
 
     const titleClasses = [
-      { 'slds-type-focus': !!titleMenu },
-      'slds-no-space'
+      'slds-page-header__title',
+      'slds-truncate',
+      { 'slds-text-link_faux': titleMenu },
     ];
 
-    const condition = closeOnClickOutside && menuIsOpen;
-
     return (
-      <div {...rest} className={cx(sldsClasses)} role="banner">
-        <Grid>
-          <Column className="slds-has-flexi-truncate">
-            <p className="slds-text-title_caps">{recordType}</p>
-            <Grid>
-              <Grid className={cx(titleClasses)}>
-                <h1
-                  onClick={titleMenu && this.toggleMenu}
-                  className="slds-page-header__title slds-truncate"
-                  title={title}
-                >
-                  {title}
-                </h1>
+      <div {...rest} className={cx(sldsClasses)}>
+        <div className="slds-page-header__row">
+          <div className="slds-page-header__col-title">
+            <MediaObject
+              figureLeft={icon ? (
+                <Icon
+                  sprite={icon.sprite}
+                  icon={icon.icon}
+                  svgClassName="slds-page-header__icon"
+                />
+              ) : null}
+            >
+              <div className="slds-page-header__name">
+                <div className="slds-page-header__name-title">
+                  <h1>
+                    <span>{recordType}</span>
+                    <span
+                      className={cx(titleClasses)}
+                      onClick={titleMenu && this.toggleMenu}
+                      title={title}
+                    >
+                      {title}
+                    </span>
+                  </h1>
+                </div>
                 {titleMenu && (
-                  <ClickOutside onClickOutside={this.onClickOutside} condition={condition}>
+                  <ClickOutside
+                    className="slds-page-header__name-switcher"
+                    onClickOutside={this.onClickOutside}
+                    condition={closeOnClickOutside && menuIsOpen}
+                  >
                     <ControlledMenu
-                      button={<IconButton
-                        container
-                        icon="down"
-                        sprite="utility"
-                        onClick={this.toggleMenu}
-                      />}
+                      button={(
+                        <IconButton
+                          container
+                          icon="down"
+                          size="small"
+                          sprite="utility"
+                          onClick={this.toggleMenu}
+                        />
+                      )}
                       isOpen={this.state.menuIsOpen}
                     >
                       {titleMenu}
                     </ControlledMenu>
                   </ClickOutside>
                 )}
-              </Grid>
-            </Grid>
-          </Column>
-          <Column className="slds-no-flex slds-grid slds-align-top">
-            {topButtons}
-          </Column>
-        </Grid>
-        <Grid>
-          <Column className="slds-align-bottom">
-            <p className="slds-page-header__info slds-text-body_small">{info}</p>
-          </Column>
-          <Column className="slds-align-bottom slds-no-flex slds-grid">{bottomButtons}</Column>
-        </Grid>
+              </div>
+            </MediaObject>
+          </div>
+          {topButtons && (
+            <div className="slds-page-header__col-actions">
+              <div className="slds-page-header__controls">
+                <div className="slds-page-header__control">
+                  {topButtons}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+        {(info || bottomButtons) && (
+          <div className="slds-page-header__row">
+            <div className="slds-page-header__col-meta">
+              {info && (
+                <p className="slds-page-header__meta-text">{info}</p>
+              )}
+            </div>
+            <div className="slds-page-header__col-controls">
+              {bottomButtons && (
+                <div className="slds-page-header__controls">{bottomButtons}</div>
+              )}
+            </div>
+          </div>
+        )}
+        {children}
       </div>
     );
   }

--- a/src/components/PageHeader/PageHeaderBase.js
+++ b/src/components/PageHeader/PageHeaderBase.js
@@ -5,29 +5,40 @@ import cx from 'classnames';
 import { Icon, MediaObject } from '../../';
 
 const PageHeaderBase = (props) => {
-  const { className, icon, info, title, ...rest } = props;
+  const {
+    className,
+    icon: { icon, sprite },
+    info,
+    title,
+    ...rest
+  } = props;
 
-  const iconRendered = <Icon sprite={icon.sprite} icon={icon.icon} />;
-
-  const sldsClasses = [
-    'slds-page-header',
-    className
-  ];
-
-  const titleClasses = [
-    'slds-page-header__title',
-    'slds-truncate',
-    'slds-align-middle'
-  ];
+  const sldsClasses = ['slds-page-header', className];
 
   return (
-    <div {...rest} className={cx(sldsClasses)} role="banner">
-      <MediaObject figureLeft={iconRendered} center>
-        <p className={cx(titleClasses)} title={title}>
-          {title}
-        </p>
-        <p className="slds-text-body_small slds-page-header__info">{info}</p>
-      </MediaObject>
+    <div {...rest} className={cx(sldsClasses)}>
+      <div className="slds-page-header__row">
+        <div className="slds-page-header__col-title">
+          <MediaObject
+            figureLeft={(
+              <Icon
+                sprite={sprite}
+                icon={icon}
+                svgClassName="slds-page-header__icon"
+              />
+            )}
+          >
+            <div className="slds-page-header__name">
+              <div className="slds-page-header__name-title">
+                <h1>
+                  <span className="slds-page-header__title slds-truncate" title={title}>{title}</span>
+                </h1>
+              </div>
+            </div>
+            <p className="slds-page-header__name-meta">{info}</p>
+          </MediaObject>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/PageHeader/RecordHome.js
+++ b/src/components/PageHeader/RecordHome.js
@@ -1,73 +1,46 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
+import { ObjectHome } from './';
 
-import { Grid, Column, MediaObject, Icon } from '../../';
-
-const RecordHome = (props) => {
-  const { className, detailItems = [], headerButtons, icon, recordType, title, ...rest } = props;
-
-  const iconRendered = <Icon sprite={icon.sprite} icon={icon.icon} />;
-  let detailRow;
-
-  if ((detailItems !== null) && (detailItems.length > 0)) {
-    const titleClasses = [
-      'slds-text-title',
-      'slds-truncate',
-      'slds-m-bottom_xx-small'
-    ];
-
-    const detailItemsRendered = detailItems.map((item, index) =>
-      // eslint-disable-next-line
-      <li className="slds-page-header__detail-block" key={`${item.title}-${index}`}>
-        <p className={cx(titleClasses)}>{item.title}</p>
-        <p className="slds-text-body_regular slds-truncate">{item.content}</p>
-      </li>
-    );
-    detailRow = (
-      <ul className="slds-grid slds-page-header__detail-row">{detailItemsRendered}</ul>
-    );
-  } else {
-    detailRow = '';
-  }
-
-  const sldsClasses = [
-    'slds-page-header',
-    className
-  ];
-
-  const pageHeaderTitleClasses = [
-    'slds-page-header__title',
-    'slds-m-right_small',
-    'slds-truncate',
-    'slds-align-middle',
-  ];
-
-  return (
-    <div {...rest} className={cx(sldsClasses)} role="banner">
-      <Grid>
-        <Column className="slds-has-flexi-truncate">
-          <MediaObject
-            center
-            figureLeft={iconRendered}
-            className="slds-grow slds-no-space"
-          >
-            <p className="slds-text-title_caps">{recordType}</p>
-            <h1 className={cx(pageHeaderTitleClasses)} title={title}>
-              {title}
-            </h1>
-          </MediaObject>
-        </Column>
-        <Column className="slds-no-flex slds-grid slds-align-bottom">{headerButtons}</Column>
-      </Grid>
-      {detailRow}
+const RecordHome = ({
+  detailItems,
+  headerButtons,
+  icon,
+  recordType,
+  title,
+  ...rest
+}) => (
+  <ObjectHome
+    {...rest}
+    icon={icon}
+    recordType={recordType}
+    title={title}
+    topButtons={headerButtons}
+    bottomButtons={null}
+    titleMenu={null}
+  >
+    <div className="slds-page-header__row slds-page-header__row_gutters">
+      <div className="slds-page-header__col-details">
+        {detailItems.length > 0 && (
+          <ul className="slds-grid slds-page-header__detail-row">
+            {detailItems.map(({ title: itemTitle, content: itemContent }, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <li className="slds-page-header__detail-block" key={`${itemTitle}-${index}`}>
+                <div className="slds-text-title slds-truncate" title={itemTitle}>{itemTitle}</div>
+                <div className="slds-truncate" title={itemContent}>{itemContent}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
-  );
-};
+  </ObjectHome>
+);
+
 
 RecordHome.defaultProps = {
   className: null,
-  detailItems: null,
+  detailItems: [],
   headerButtons: null
 };
 

--- a/src/components/PageHeader/__tests__/ObjectHome.spec.js
+++ b/src/components/PageHeader/__tests__/ObjectHome.spec.js
@@ -21,7 +21,7 @@ describe('<ObjectHome />', () => {
   });
 
   it('opens the menu on headline click', () => {
-    const headline = mounted.find('h1').first();
+    const headline = mounted.find('.slds-page-header__title');
     const dropdown = mounted.find('div.slds-dropdown-trigger').first();
     expect(dropdown.hasClass('slds-is-open')).toBeFalsy();
     headline.simulate('click');
@@ -29,39 +29,33 @@ describe('<ObjectHome />', () => {
   });
 
   it('contains the title', () => {
-    expect(mounted.find('h1').first().text()).toEqual('foo');
+    expect(mounted.find('.slds-page-header__title').text()).toEqual('foo');
+  });
+
+  it('contains the recordType', () => {
+    expect(mounted.find('h1 span').first().text()).toEqual('unicornz');
   });
 
   it('contains the titleMenu', () => {
-    const headline = mounted.find('h1').first();
+    const headline = mounted.find('.slds-page-header__title');
     headline.simulate('click');
     expect(mounted.find('.slds-dropdown').exists()).toBeTruthy();
   });
 
-  it('contains the recordType', () => {
-    expect(mounted.find('p.slds-text-title_caps').first().text()).toEqual('unicornz');
-  });
-
   it('contains topButtons', () => {
     expect(mounted
-      .find('div.slds-grid')
-      .first()
-      .children()
-      .at(1)
+      .find('.slds-page-header__col-actions')
       .text())
       .toEqual('button098');
   });
 
   it('contains info', () => {
-    expect(mounted.find('p.slds-text-body_small').text()).toEqual('yeah');
+    expect(mounted.find('.slds-page-header__meta-text').text()).toEqual('yeah');
   });
 
   it('contains bottomButtons', () => {
     expect(mounted
-      .find('div.slds-grid')
-      .at(4)
-      .children()
-      .at(1)
+      .find('.slds-page-header__col-controls')
       .text())
       .toEqual('button1234');
   });

--- a/src/components/PageHeader/__tests__/PageHeaderBase.spec.js
+++ b/src/components/PageHeader/__tests__/PageHeaderBase.spec.js
@@ -11,11 +11,11 @@ describe('<PageHeaderBase />', () => {
   });
 
   it('contains the title', () => {
-    expect(mounted.find('p.slds-page-header__title').text()).toEqual('test');
+    expect(mounted.find('h1 .slds-page-header__title').text()).toEqual('test');
   });
 
   it('contains info', () => {
-    expect(mounted.find('p.slds-text-body_small').text()).toEqual('foo');
+    expect(mounted.find('.slds-page-header__name-meta').text()).toEqual('foo');
   });
 
   it('renders the icon', () => {

--- a/src/components/PageHeader/__tests__/RecordHome.spec.js
+++ b/src/components/PageHeader/__tests__/RecordHome.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import RecordHome from '../RecordHome';
+import ObjectHome from '../ObjectHome';
 
 describe('<RecordHome />', () => {
   let mounted;
@@ -21,29 +22,23 @@ describe('<RecordHome />', () => {
     );
   });
 
-  it('contains the icon', () => {
-    expect(mounted.find('svg').length).toEqual(1);
-  });
-
-  it('contains the title', () => {
-    expect(mounted.find('h1').first().text()).toEqual('foo');
-  });
-
-  it('contains the recordType', () => {
-    expect(mounted.find('p.slds-text-title_caps').first().text()).toEqual('unicornz');
-  });
-
-  it('contains the headerButtons', () => {
-    expect(mounted.find('div.slds-col').at(1).text()).toEqual('button123');
+  it('passes down props to ObjectHome', () => {
+    expect(mounted.find(ObjectHome).prop('icon')).toEqual({ sprite: 'utility', icon: 'unicornz' });
+    expect(mounted.find(ObjectHome).prop('title')).toEqual('foo');
+    expect(mounted.find(ObjectHome).prop('recordType')).toEqual('unicornz');
+    expect(mounted.find(ObjectHome).prop('topButtons')).toEqual('button123');
+    mounted.setProps({ bottomButtons: 'abc', titleMenu: 'foo' });
+    expect(mounted.find(ObjectHome).prop('bottomButtons')).toBeNull();
+    expect(mounted.find(ObjectHome).prop('titleMenu')).toBeNull();
   });
 
   it('contains detail items', () => {
     const detailItems = mounted.find('li.slds-page-header__detail-block');
     expect(detailItems.length).toEqual(2);
-    expect(detailItems.first().find('p.slds-text-title').text()).toEqual('detail1');
-    expect(detailItems.first().find('p.slds-text-body_regular').text()).toEqual('detailcontent1');
-    expect(detailItems.at(1).find('p.slds-text-title').text()).toEqual('detail2');
-    expect(detailItems.at(1).find('p.slds-text-body_regular').text()).toEqual('detailcontent2');
+    expect(detailItems.first().find('div.slds-text-title').text()).toEqual('detail1');
+    expect(detailItems.first().find('div[title="detailcontent1"]').text()).toEqual('detailcontent1');
+    expect(detailItems.at(1).find('div.slds-text-title').text()).toEqual('detail2');
+    expect(detailItems.at(1).find('div[title="detailcontent2"]').text()).toEqual('detailcontent2');
   });
 
   it('applies className and rest-properties', () => {

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -47,13 +47,21 @@ const propTypes = {
   nubbin: PropTypes.oneOf([
     'left',
     'left-top',
+    'left-top-corner',
     'left-bottom',
+    'left-bottom-corner',
     'top-left',
+    'top-left-corner',
     'top-right',
+    'top-right-corner',
     'right-top',
+    'right-top-corner',
     'right-bottom',
+    'right-bottom-corner',
     'bottom-left',
+    'bottom-left-corner',
     'bottom-right',
+    'bottom-right-corner',
   ]),
   /**
    * Optional custom Header theme. Themes: warning, error, success, info

--- a/src/components/Progress/DescriptiveProgressBar.js
+++ b/src/components/Progress/DescriptiveProgressBar.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from '../Grid';
+import { getClampedProgress } from './utils';
+import ProgressBar from './ProgressBar';
+
+const DescriptiveProgressBar = ({
+  completeLabel,
+  id,
+  label,
+  max,
+  min,
+  progress,
+  ...rest
+}) => (
+  <div>
+    <Grid className="slds-p-bottom_x-small" align="spread" id={id}>
+      <span>{label}</span>
+      <span aria-hidden="true">
+        <strong>{getClampedProgress(progress, min, max)}% {completeLabel}</strong>
+      </span>
+    </Grid>
+    <ProgressBar
+      aria-labelledby={id}
+      completeLabel={completeLabel}
+      min={min}
+      max={max}
+      progress={progress}
+      {...rest}
+    />
+  </div>
+);
+
+DescriptiveProgressBar.defaultProps = {
+  completeLabel: 'Complete',
+  max: 100,
+  min: 0,
+  progress: 0,
+};
+
+DescriptiveProgressBar.propTypes = {
+  /** Labels the 'Complete' percentage, e.g. "25% Complete" */
+  completeLabel: PropTypes.string,
+  /** Ties label to ProgressBar for assistive technology */
+  id: PropTypes.string.isRequired,
+  /** Main label */
+  label: PropTypes.string.isRequired,
+  /** See ProgressBar */
+  max: PropTypes.number,
+  /** See ProgressBar */
+  min: PropTypes.number,
+  /** See ProgressBar */
+  progress: PropTypes.number,
+};
+
+export default DescriptiveProgressBar;

--- a/src/components/Progress/ProgressBar.js
+++ b/src/components/Progress/ProgressBar.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { clamp, fraction } from './utils';
 
-const getBarValueStyle = num => ({
-  width: `${num}%`,
+const getBarValueStyle = (num, vertical) => ({
+  [vertical ? 'height' : 'width']: `${num}%`,
 });
 
 const ProgressBar = (props) => {
@@ -17,6 +17,7 @@ const ProgressBar = (props) => {
     progress,
     size,
     success,
+    vertical,
     ...rest
   } = props;
 
@@ -26,6 +27,7 @@ const ProgressBar = (props) => {
     baseClass,
     { [`${baseClass}_${size}`]: !!size },
     { [`${baseClass}_circular`]: circular },
+    { [`${baseClass}_vertical`]: vertical },
     className
   ];
 
@@ -45,7 +47,7 @@ const ProgressBar = (props) => {
       aria-valuenow={clampedProgress}
       role="progressbar"
     >
-      <span className={cx(valueClasses)} style={getBarValueStyle(clampedProgress)}>
+      <span className={cx(valueClasses)} style={getBarValueStyle(clampedProgress, vertical)}>
         <span className="slds-assistive-text">{`${assistiveLabel}: ${clampedProgress}%`}</span>
       </span>
     </div>
@@ -61,6 +63,7 @@ ProgressBar.defaultProps = {
   max: 100,
   size: null,
   success: false,
+  vertical: false,
 };
 
 ProgressBar.propTypes = {
@@ -96,6 +99,10 @@ ProgressBar.propTypes = {
    * Render a green progress bar
    */
   success: PropTypes.bool,
+  /**
+   * Renders as a vertical progress bar
+   */
+  vertical: PropTypes.bool,
 };
 
 export default ProgressBar;

--- a/src/components/Progress/ProgressBar.js
+++ b/src/components/Progress/ProgressBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { clamp, fraction } from './utils';
+import { getClampedProgress } from './utils';
 
 const getBarValueStyle = (num, vertical) => ({
   [vertical ? 'height' : 'width']: `${num}%`,
@@ -11,6 +11,7 @@ const ProgressBar = (props) => {
   const {
     assistiveLabel,
     circular,
+    completeLabel,
     className,
     min,
     max,
@@ -36,7 +37,7 @@ const ProgressBar = (props) => {
     { [`${baseClass}__value_success`]: success },
   ];
 
-  const clampedProgress = fraction(clamp(progress, min, max), min, max) * 100;
+  const clampedProgress = getClampedProgress(progress, min, max);
 
   return (
     <div
@@ -48,14 +49,20 @@ const ProgressBar = (props) => {
       role="progressbar"
     >
       <span className={cx(valueClasses)} style={getBarValueStyle(clampedProgress, vertical)}>
-        <span className="slds-assistive-text">{`${assistiveLabel}: ${clampedProgress}%`}</span>
+        <span className="slds-assistive-text">
+          {assistiveLabel
+            ? `${assistiveLabel}: ${clampedProgress}%`
+            : `${clampedProgress}% ${completeLabel}`
+          }
+        </span>
       </span>
     </div>
   );
 };
 
 ProgressBar.defaultProps = {
-  assistiveLabel: 'Progress',
+  assistiveLabel: null,
+  completeLabel: 'Complete',
   circular: false,
   className: null,
   progress: 0,
@@ -68,9 +75,13 @@ ProgressBar.defaultProps = {
 
 ProgressBar.propTypes = {
   /**
-   * Assistive label. Interpolates to `${label}: x%`
+   * (DEPRECATED) Assistive label. Interpolates to `${label}: x%`
    */
   assistiveLabel: PropTypes.string,
+  /**
+   * Assistive label. Interpolates to `x% ${label}`
+   */
+  completeLabel: PropTypes.string,
   /**
    * Render progress bar with round edges instead
    */

--- a/src/components/Progress/ProgressRing.js
+++ b/src/components/Progress/ProgressRing.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { clamp, fraction } from './utils';
+import { getClampedProgress } from './utils';
 import { Icon } from '../../';
 
 const getIconForStatus = (status, labels) => {
@@ -45,9 +45,9 @@ const ProgressRing = (props) => {
 
   const baseClass = 'slds-progress-ring';
 
-  const percComplete = fraction(clamp(progress, min, max), min, max);
+  const percComplete = getClampedProgress(progress, min, max);
 
-  const isForceComplete = complete === true || (complete === 'auto' && percComplete === 1);
+  const isForceComplete = complete === true || (complete === 'auto' && percComplete === 100);
   const currentStatus = isForceComplete ? 'complete' : status;
 
   const iconEl = !currentStatus && customIcon
@@ -71,9 +71,9 @@ const ProgressRing = (props) => {
         role="progressbar"
         aria-valuemin={min}
         aria-valuemax={max}
-        aria-valuenow={percComplete * 100}
+        aria-valuenow={percComplete}
       >
-        <svg viewBox="-1 -1 2 2">{getPath(percComplete, isForceComplete, variant)}</svg>
+        <svg viewBox="-1 -1 2 2">{getPath(percComplete / 100, isForceComplete, variant)}</svg>
       </div>
       <div className="slds-progress-ring__content">{iconEl}</div>
     </div>
@@ -89,8 +89,9 @@ ProgressRing.defaultProps = {
   className: null,
   complete: 'auto',
   customIcon: null,
-  max: 100,
   min: 0,
+  max: 100,
+  progress: 0,
   size: null,
   status: null,
   variant: 'fill',
@@ -121,7 +122,7 @@ ProgressRing.propTypes = {
   /**
    * Progress value (between min-max)
    */
-  progress: PropTypes.number.isRequired,
+  progress: PropTypes.number,
   /**
    * Progress min
    */

--- a/src/components/Progress/ProgressRing.js
+++ b/src/components/Progress/ProgressRing.js
@@ -11,7 +11,7 @@ const getIconForStatus = (status, labels) => {
   return <Icon sprite="utility" icon="check" title={labels.complete} />;
 };
 
-const getPath = (progress, isComplete) => {
+const getPath = (progress, isComplete, variant) => {
   const prefix = 'M 1 0 A 1 1 0';
   const postfix = 'L 0 0';
 
@@ -20,7 +20,9 @@ const getPath = (progress, isComplete) => {
   if (!isComplete) {
     const deg = 2 * Math.PI * progress;
     const isLong = progress >= 0.5 ? '1' : '0';
-    d = `${prefix} ${isLong} 1 ${Math.cos(deg)} ${Math.sin(deg)} ${postfix}`;
+    d = variant === 'fill'
+      ? `${prefix} ${isLong} 0 ${Math.cos(deg)} ${-Math.sin(deg)} ${postfix}`
+      : `${prefix} ${isLong} 1 ${Math.cos(deg)} ${Math.sin(deg)} ${postfix}`;
   }
 
   return <path className="slds-progress-ring__path" d={d} />;
@@ -35,7 +37,9 @@ const ProgressRing = (props) => {
     min,
     max,
     progress,
+    size,
     status,
+    variant,
     ...rest
   } = props;
 
@@ -54,6 +58,7 @@ const ProgressRing = (props) => {
     baseClass,
     { [`${baseClass}_${currentStatus}`]: !!currentStatus },
     className,
+    { [`${baseClass}_${size}`]: !!size },
   ];
 
   return (
@@ -68,7 +73,7 @@ const ProgressRing = (props) => {
         aria-valuemax={max}
         aria-valuenow={percComplete * 100}
       >
-        <svg viewBox="-1 -1 2 2">{getPath(percComplete, isForceComplete)}</svg>
+        <svg viewBox="-1 -1 2 2">{getPath(percComplete, isForceComplete, variant)}</svg>
       </div>
       <div className="slds-progress-ring__content">{iconEl}</div>
     </div>
@@ -81,12 +86,14 @@ ProgressRing.defaultProps = {
     expired: 'Expired',
     warning: 'Warning',
   },
-  complete: 'auto',
   className: null,
+  complete: 'auto',
   customIcon: null,
-  min: 0,
   max: 100,
+  min: 0,
+  size: null,
   status: null,
+  variant: 'fill',
 };
 
 ProgressRing.propTypes = {
@@ -124,9 +131,17 @@ ProgressRing.propTypes = {
    */
   max: PropTypes.number,
   /**
+   * large size
+   */
+  size: PropTypes.oneOf(['large']),
+  /**
    * Progress status. Can be: 'expired' or 'warning'
    */
-  status: PropTypes.oneOf(['expired', 'warning']),
+  status: PropTypes.oneOf(['expired', 'warning', 'active-step']),
+  /**
+   * fill or drain the ring (fill means the colored portion of the ring increases clockwise)
+   */
+  variant: PropTypes.oneOf(['fill', 'drain']),
 };
 
 export default ProgressRing;

--- a/src/components/Progress/__tests__/DescriptiveProgressBar.spec.js
+++ b/src/components/Progress/__tests__/DescriptiveProgressBar.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import DescriptiveProgressBar from '../DescriptiveProgressBar';
+import { Grid } from '../../Grid';
+import ProgressBar from '../ProgressBar';
+
+const getProgressBar = (props = {}) => shallow(
+  <DescriptiveProgressBar label="bar" id="foo" progress={0} {...props} />
+);
+
+describe('<DescriptiveProgressBar />', () => {
+  it('renders a label and a percentageLabel', () => {
+    const mounted = getProgressBar({ progress: 25 });
+    expect(mounted.find(Grid).find('span').at(0).text()).toEqual('bar');
+    expect(mounted.find(Grid).find('span').at(1).text()).toEqual('25% Complete');
+  });
+
+  it('applies an id and associates it with the input', () => {
+    const mounted = getProgressBar({ progress: 25 });
+    expect(mounted.find(Grid).prop('id')).toEqual('foo');
+    expect(mounted.find(ProgressBar).prop('aria-labelledby')).toEqual('foo');
+  });
+
+  it('passes rest and progress props to ProgressBar', () => {
+    const mounted = getProgressBar({ className: 'baz', progress: 25 });
+    const progressbar = mounted.find(ProgressBar);
+    expect(progressbar.prop('progress')).toEqual(25);
+    expect(progressbar.prop('className')).toEqual('baz');
+  });
+});

--- a/src/components/Progress/__tests__/ProgressBar.spec.js
+++ b/src/components/Progress/__tests__/ProgressBar.spec.js
@@ -13,6 +13,14 @@ describe('<ProgressBar />', () => {
     });
   });
 
+  it('renders as vertical layout', () => {
+    const mounted = getProgressBar({ progress: 50, vertical: true });
+    expect(mounted.find('.slds-progress-bar__value').prop('style')).toEqual({
+      height: '50%',
+    });
+  });
+
+
   it('clamps the maximum value to 100', () => {
     const mounted = getProgressBar({ progress: 500 });
     expect(mounted.find('.slds-progress-bar').prop('aria-valuenow')).toEqual(100);

--- a/src/components/Progress/__tests__/ProgressBar.spec.js
+++ b/src/components/Progress/__tests__/ProgressBar.spec.js
@@ -20,7 +20,6 @@ describe('<ProgressBar />', () => {
     });
   });
 
-
   it('clamps the maximum value to 100', () => {
     const mounted = getProgressBar({ progress: 500 });
     expect(mounted.find('.slds-progress-bar').prop('aria-valuenow')).toEqual(100);
@@ -54,5 +53,12 @@ describe('<ProgressBar />', () => {
   it('supports setting min & max', () => {
     const cmp = getProgressBar({ progress: 100, min: -200, max: 200 });
     expect(cmp.find('.slds-progress-bar').prop('aria-valuenow')).toEqual(75);
+  });
+
+  it('applies assistiveLabel and falls back to completeLabel if not set', () => {
+    const cmp = getProgressBar({ assistiveLabel: 'label' });
+    expect(cmp.find('.slds-assistive-text').text()).toEqual('label: 0%');
+    cmp.setProps({ assistiveLabel: null });
+    expect(cmp.find('.slds-assistive-text').text()).toEqual('0% Complete');
   });
 });

--- a/src/components/Progress/__tests__/ProgressRing.spec.js
+++ b/src/components/Progress/__tests__/ProgressRing.spec.js
@@ -20,6 +20,11 @@ describe('<ProgressRing />', () => {
     expect(cmp.find(Icon).prop('icon')).toEqual('error');
   });
 
+  it('renders necessary class in active-step status', () => {
+    const cmp = getCmp({ status: 'active-step' });
+    expect(cmp.find('.slds-progress-ring').hasClass('slds-progress-ring_active-step'));
+  });
+
   it('autocompletes by default', () => {
     const cmp = getCmp({ progress: 100 });
     expect(cmp.find('.slds-progress-ring').hasClass('slds-progress-ring_complete')).toBeTruthy();
@@ -59,5 +64,10 @@ describe('<ProgressRing />', () => {
   it('supports setting min & max', () => {
     const cmp = getCmp({ progress: 100, min: -200, max: 200 });
     expect(cmp.find('.slds-progress-ring__progress').prop('aria-valuenow')).toEqual(75);
+  });
+
+  it('renders in large size', () => {
+    const cmp = getCmp({ size: 'large' });
+    expect(cmp.find('.slds-progress-ring').hasClass('slds-progress-ring_large'));
   });
 });

--- a/src/components/Progress/index.js
+++ b/src/components/Progress/index.js
@@ -1,4 +1,5 @@
+import DescriptiveProgressBar from './DescriptiveProgressBar';
 import ProgressBar from './ProgressBar';
 import ProgressRing from './ProgressRing';
 
-export { ProgressBar, ProgressRing };
+export { DescriptiveProgressBar, ProgressBar, ProgressRing };

--- a/src/components/Progress/utils/index.js
+++ b/src/components/Progress/utils/index.js
@@ -1,8 +1,12 @@
 
-export function clamp(num, min = 0, max = 100) {
+function clamp(num, min = 0, max = 100) {
   return Math.min(Math.max(num, min), max);
 }
 
-export function fraction(num, min = 0, max = 100) {
+function fraction(num, min = 0, max = 100) {
   return ((num - min) / (max - min));
+}
+
+export function getClampedProgress(progress, min, max) {
+  return fraction(clamp(progress, min, max), min, max) * 100;
 }

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
+import { SpinnerContainer } from './';
 
 const Spinner = (props) => {
   const {
     assistiveLabel,
     className,
+    container,
     delayed,
     flavor,
+    inline,
     size,
     ...rest
   } = props;
@@ -19,24 +22,30 @@ const Spinner = (props) => {
     { [`${baseClass}_${size}`]: !!size },
     { [`${baseClass}_${flavor}`]: !!flavor },
     { [`${baseClass}_delayed`]: !!delayed },
-    className
+    { [`${baseClass}_inline`]: !!inline },
+    className,
   ];
 
-  return (
+  const spinner = (
     <div {...rest} role="status" className={cx(sldsClasses)}>
       <span className="slds-assistive-text">{assistiveLabel}</span>
       <div className="slds-spinner__dot-a" />
       <div className="slds-spinner__dot-b" />
     </div>
   );
+
+  if (container) return <SpinnerContainer>{spinner}</SpinnerContainer>;
+  return spinner;
 };
 
 Spinner.defaultProps = {
   assistiveLabel: 'Loading',
   className: null,
+  container: false,
   delayed: false,
   flavor: null,
-  size: 'medium'
+  inline: false,
+  size: 'medium',
 };
 
 Spinner.propTypes = {
@@ -49,6 +58,10 @@ Spinner.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * convenience prop to wrap Spinner in SpinnerContainer
+   */
+  container: PropTypes.bool,
+  /**
    * Adds a 300ms start delay
    */
   delayed: PropTypes.bool,
@@ -56,6 +69,10 @@ Spinner.propTypes = {
    * Flavor. Can be either 'brand' or 'inverse'
    */
   flavor: PropTypes.oneOf(['brand', 'inverse']),
+  /**
+   * inline variation
+   */
+  inline: PropTypes.bool,
   /**
    * spinner sizes: xx-small, x-small, small, medium, large
    */

--- a/src/components/Spinner/__tests__/Spinner.spec.js
+++ b/src/components/Spinner/__tests__/Spinner.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import Spinner from '../Spinner';
 import SpinnerContainer from '../SpinnerContainer';
@@ -55,5 +55,11 @@ describe('<Spinner />', () => {
     const mounted = shallow(<SpinnerContainer className="foo" data-test="bar"><Spinner /></SpinnerContainer>);
     expect(mounted.find('.slds-spinner_container').hasClass('foo')).toBeTruthy();
     expect(mounted.find('.slds-spinner_container').prop('data-test')).toEqual('bar');
+  });
+
+  it('renders in SpinnerContainer when \'container\' prop is used on Spinner', () => {
+    const mounted = mount(<Spinner container />);
+    expect(mounted.find('.slds-spinner_container').length).toBe(1);
+    expect(mounted.find('.slds-spinner_container').children().length).toBe(1);
   });
 });

--- a/src/components/Table/Row.js
+++ b/src/components/Table/Row.js
@@ -8,7 +8,7 @@ const Row = (props) => {
   const variationClasses = Array.isArray(variation) ? variation.map(f => `slds-${f}`) : `slds-${variation}`;
 
   const sldsClasses = [
-    { 'slds-text-title_caps': !!head },
+    { 'slds-text-title_caps': head },
     variationClasses,
     className
   ];

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -58,6 +58,7 @@ export const propTypes = {
     'col-bordered',
     'striped',
     'fixed-layout',
+    'header-hidden',
   ]),
 };
 

--- a/src/components/Tabs/ControlledTabs.js
+++ b/src/components/Tabs/ControlledTabs.js
@@ -9,6 +9,7 @@ class ControlledTabs extends PureComponent {
   static defaultProps = {
     renderInactiveTabs: false,
     scoped: false,
+    size: null,
     styled: false,
   }
 
@@ -33,6 +34,10 @@ class ControlledTabs extends PureComponent {
      * Renders scoped variant
      */
     scoped: PropTypes.bool,
+    /**
+     * Size modifier
+     */
+    size: PropTypes.oneOf(['medium', 'large']),
     /**
      * Renders Card-like variant
      */
@@ -183,15 +188,21 @@ class ControlledTabs extends PureComponent {
   }
 
   render() {
-    const { scoped, styled, children } = this.props;
+    const {
+      children,
+      scoped,
+      size,
+      styled,
+    } = this.props;
+
+    const sldsClasses = [
+      getTabsClass('', scoped),
+      { 'slds-tabs_card': styled },
+      { [`slds-tabs_${size}`]: size }
+    ];
 
     return (
-      <div
-        className={cx(
-          getTabsClass('', scoped),
-          { 'slds-tabs_card': styled }
-        )}
-      >
+      <div className={cx(sldsClasses)}>
         <ul
           className={getTabsClass('__nav', scoped)}
           onBlur={this.onBlur}

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -8,6 +8,7 @@ class Tabs extends Component {
     onChangeTab: null,
     renderInactiveTabs: false,
     scoped: false,
+    size: null,
     styled: false,
   }
 
@@ -33,6 +34,10 @@ class Tabs extends Component {
      * Renders scoped variant
      */
     scoped: PropTypes.bool,
+    /**
+     * Size modifier
+     */
+    size: PropTypes.oneOf(['medium', 'large']),
     /**
      * Renders Card-like variant
      */

--- a/src/components/Tabs/__tests__/ControlledTabs.spec.js
+++ b/src/components/Tabs/__tests__/ControlledTabs.spec.js
@@ -23,7 +23,7 @@ describe('<ControlledTabs />', () => {
   it('renders size modifiers', () => {
     const mounted = getComponent({ size: 'large' });
     expect(mounted.find('.slds-tabs_default').hasClass('slds-tabs_large')).toBeTruthy();
-  })
+  });
 
   it('renders a link for every tab passed', () => {
     const mounted = getComponent();

--- a/src/components/Tabs/__tests__/ControlledTabs.spec.js
+++ b/src/components/Tabs/__tests__/ControlledTabs.spec.js
@@ -20,6 +20,11 @@ const getTabLink = (mounted, pos = 0) => mounted.find(TabLink).at(pos);
 const getTab = (mounted, pos = 0) => mounted.find(Tab).at(pos);
 
 describe('<ControlledTabs />', () => {
+  it('renders size modifiers', () => {
+    const mounted = getComponent({ size: 'large' });
+    expect(mounted.find('.slds-tabs_default').hasClass('slds-tabs_large')).toBeTruthy();
+  })
+
   it('renders a link for every tab passed', () => {
     const mounted = getComponent();
     expect(mounted.find(TabLink).length).toEqual(3);

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -14,10 +14,14 @@ import {
 
 const buttonFlavors = [
   'none',
-  'neutral',
   'brand',
-  'success',
   'destructive',
+  'inverse',
+  'neutral',
+  'none',
+  'outline-brand',
+  'success',
+  'text-destructive',
 ];
 
 const buttonStories = storiesOf('Button', module);

--- a/stories/ButtonGroup.js
+++ b/stories/ButtonGroup.js
@@ -15,7 +15,10 @@ const stories = storiesOf('ButtonGroup', module);
 
 stories
   .add('Default', () => (
-    <ButtonGroup list={boolean('Render as list', false)}>
+    <ButtonGroup
+      list={boolean('Render as list', false)}
+      row={boolean('Render as row', false)}
+    >
       <Button title="Refresh" />
       <Button title="Edit" />
       <Button title="Save" disabled={boolean('Disable last button', false)} />

--- a/stories/Card.js
+++ b/stories/Card.js
@@ -12,7 +12,7 @@ stories
       icon={<Icon sprite="standard" icon="contact" />}
       title={text('Title', 'Base Card')}
       headerRight={<Button title="New" onClick={action('click')}>New</Button>}
-      footer="Footer"
+      footer={(<a className="slds-card__footer-action">View All</a>)}
     >
       Body would be here
     </Card>

--- a/stories/File.js
+++ b/stories/File.js
@@ -47,9 +47,9 @@ stories
     <File
       href="#"
       externalIcon={object('ExternalIcon', {
-        icon: 'generic_loading',
-        sprite: 'standard',
-        title: 'custom icon',
+        icon: 'salesforce1',
+        sprite: 'utility',
+        title: 'External Icon',
       })}
       fileType={getFileTypes() || undefined}
       title={text('Title', 'Proposal.pdf')}

--- a/stories/Form.js
+++ b/stories/Form.js
@@ -22,30 +22,30 @@ const stories = storiesOf('Form', module);
 stories
   .add('Input', () => (
     <Input
-      id="input-1"
-      bare={boolean('Bare', false)}
-      disabled={boolean('Disabled', false) || undefined}
-      error={text('Error', '') || undefined}
-      errorIcon={boolean('ErrorIcon', false) || undefined}
-      hideLabel={boolean('Hide Label', false) || undefined}
-      iconLeft={getUtilityIcons('Icon left') || undefined}
-      iconRight={getUtilityIcons('Icon right') || undefined}
-      iconRightOnClick={action('clicked right icon')}
-      isFocused={boolean('IsFocused', false) || undefined}
       label={text('Label', 'default input')}
-      onChange={action('changed input')}
-      onFocus={action('focussed')}
-      onKeyPress={action('key pressed')}
       placeholder={text('Placeholder', 'Placeholder')}
-      readOnly={boolean('Read Only', false) || undefined}
-      role={text('Role', 'input role')}
-      required={boolean('Required', false) || undefined}
-      showSpinner={boolean('Show Spinner', false) || undefined}
+      value={text('Value', '') || undefined}
       type={select('Type', [
         'text', 'password', 'datetime', 'datetime-local', 'date', 'month',
         'time', 'week', 'number', 'email', 'url', 'search', 'tel', 'color'
       ], 'text')}
-      value={text('Value', '') || undefined}
+      bare={boolean('Bare', false)}
+      disabled={boolean('Disabled', false) || undefined}
+      hideLabel={boolean('Hide Label', false) || undefined}
+      isStatic={boolean('Static', false) || undefined}
+      readOnly={boolean('Read Only', false) || undefined}
+      required={boolean('Required', false) || undefined}
+      showSpinner={boolean('Show Spinner', false) || undefined}
+      error={text('Error', '') || undefined}
+      errorIcon={boolean('ErrorIcon', false) || undefined}
+      iconLeft={getUtilityIcons('Icon left') || undefined}
+      iconRight={getUtilityIcons('Icon right') || undefined}
+      iconRightOnClick={action('clicked right icon')}
+      role={text('Role', 'input role')}
+      onChange={action('changed input')}
+      onFocus={action('focussed')}
+      onKeyPress={action('key pressed')}
+      id="input-1"
     />
   ))
   .add('Textarea', () => (

--- a/stories/Grid.js
+++ b/stories/Grid.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { array, select, text } from '@storybook/addon-knobs';
+import { array, select, text, boolean } from '@storybook/addon-knobs';
 import { Box, Column, Grid, Container } from '../src';
 import { getThemes } from './utils/helpers';
 
@@ -34,6 +34,7 @@ stories
       className="slds-m-bottom--large"
       flavor={array('Grid Flavor', [])}
       gutters={select('Gutters', sizeOptions, 'small')}
+      guttersDirect={boolean('Direct Gutters', false)}
       align={select('Horizontal Alignment', alignOptions) || undefined}
       verticalAlign={select('Vertical Alignment', vAlignOptions, 'start')}
     >

--- a/stories/Image.js
+++ b/stories/Image.js
@@ -1,13 +1,41 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, text } from '@storybook/addon-knobs';
-import { Avatar } from '../src';
+import { boolean, text, select } from '@storybook/addon-knobs';
+import { Avatar, UserAvatar, EntityAvatar } from '../src';
 import { getSizes } from './utils/helpers';
 
 const stories = storiesOf('Image', module);
 
 stories
-  .add('Default', () => (
+  .add('User Avatar', () => (
+    <UserAvatar
+      imageSrc={text('Src', 'assets/images/avatar2.jpg')}
+      fallbackType={select('Fallback (remove imageSrc to see)', [
+        'profile-image',
+        'group-image',
+        'icon',
+        'initials',
+        'initials-inverse'
+      ], 'icon')}
+      name={text('User Name', 'John Doe')}
+      round={boolean('Round?', false)}
+      size={getSizes()}
+      title={text('Title', 'Avatar of record owner')}
+    />
+  ))
+  .add('Entity Avatar', () => (
+    <EntityAvatar
+      displayType={select('Fallback Type (remove imageSrc to see effect', ['icon', 'initials'], 'icon')}
+      icon={{
+        sprite: 'standard',
+        icon: 'account',
+      }}
+      name={text('Entity Name', 'Record Type')}
+      size={getSizes()}
+      title={text('Title', 'Icon of Record Type')}
+    />
+  ))
+  .add('Avatar (Deprecated)', () => (
     <Avatar
       alt={text('Alt', 'alt text')}
       src={text('Src', 'assets/images/avatar2.jpg')}

--- a/stories/Menu.js
+++ b/stories/Menu.js
@@ -19,11 +19,15 @@ const customButton = (
 const positions = [
   '',
   'top-left',
+  'top-left-corner',
   'top',
   'top-right',
+  'top-right-corner',
   'bottom-left',
+  'bottom-left-corner',
   'bottom',
-  'bottom-right'
+  'bottom-right',
+  'bottom-right-corner',
 ];
 
 stories

--- a/stories/PageHeader.js
+++ b/stories/PageHeader.js
@@ -110,12 +110,14 @@ stories
       titleMenu={titleMenu}
       topButtons={topButtons}
       info={text('Info', '10 items • sorted by name')}
+      icon={object('Icon', { icon: 'user', sprite: 'standard' })}
       bottomButtons={bottomButtons}
     />
   ))
   .add('ObjectHome without menu', () => (
     <ObjectHome
       title={text('Title', 'My Leads')}
+      icon={object('Icon', { icon: 'user', sprite: 'standard' })}
       recordType={text('RecordType', 'Leads')}
       topButtons={topButtons}
       info={text('Info', '10 items • sorted by name')}

--- a/stories/ProgressBar.js
+++ b/stories/ProgressBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { number, select, boolean } from '@storybook/addon-knobs';
-import { ProgressBar } from '../src';
+import { number, select, boolean, text } from '@storybook/addon-knobs';
+import { ProgressBar, DescriptiveProgressBar } from '../src';
 
 const stories = storiesOf('Progress Bar', module);
 
@@ -24,4 +24,11 @@ stories
         vertical
       />
     </div>
+  ))
+  .add('Descriptive Progressbar', () => (
+    <DescriptiveProgressBar
+      completeLabel={text('Complete Label', 'Completed')}
+      label={text('Label', 'Setup Assistant')}
+      progress={number('Progress', 33, { range: true, min: 0, max: 100, step: 1, })}
+    />
   ));

--- a/stories/ProgressBar.js
+++ b/stories/ProgressBar.js
@@ -13,4 +13,15 @@ stories
       progress={number('Progress', 33, { range: true, min: 0, max: 100, step: 1, })}
       success={boolean('Success Style', false)}
     />
+  ))
+  .add('Vertical', () => (
+    <div style={{ height: '200px' }}>
+      <ProgressBar
+        circular={boolean('Circular', false)}
+        size={select('Size', ['', 'x-small', 'small', 'medium', 'large']) || undefined}
+        progress={number('Progress', 33, { range: true, min: 0, max: 100, step: 1, })}
+        success={boolean('Success Style', false)}
+        vertical
+      />
+    </div>
   ));

--- a/stories/ProgressRing.js
+++ b/stories/ProgressRing.js
@@ -9,18 +9,21 @@ stories
   .add('Default', () => (
     <ProgressRing
       complete="auto"
-      status={select('Status', ['', 'expired', 'warning'], '') || undefined}
       progress={number('Progress', 88, { range: true, min: 0, max: 100, step: 1, })}
-
+      size={select('Size', ['', 'large'], '') || undefined}
+      status={select('Status', ['', 'expired', 'warning', 'active-step'], '') || undefined}
+      variant={select('Variant', ['fill', 'drain'], 'fill')}
     />
   ))
   .add('With Custom Icon & Manual Completion', () => (
     <ProgressRing
       complete={boolean('Complete?', false)}
       customIcon={<Icon className="slds-current-color" sprite="doctype" icon="attachment" />}
-      status={select('Status', ['', 'expired', 'warning'], '') || undefined}
-      progress={number('Progress', 88, { range: true, min: 50, max: 200, step: 1, })}
-      min={50}
       max={200}
+      min={50}
+      progress={number('Progress', 88, { range: true, min: 50, max: 200, step: 1, })}
+      size={select('Size', ['', 'large'], '') || undefined}
+      status={select('Status', ['', 'expired', 'warning', 'active-step'], '') || undefined}
+      variant={select('Variant', ['fill', 'drain'], 'fill')}
     />
-  ))
+  ));

--- a/stories/Spinner.js
+++ b/stories/Spinner.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select } from '@storybook/addon-knobs';
-import { Spinner, SpinnerContainer } from '../src';
+import { Button, Spinner, SpinnerContainer } from '../src';
 import { getSizes } from './utils/helpers';
 import { SpinnerDecorator } from './utils/decorators';
 
@@ -14,6 +14,7 @@ stories
       delayed={boolean('Delayed', true)}
       flavor={select('Flavor', ['', 'brand', 'inverse'], '') || undefined}
       size={getSizes()}
+      inline={boolean('Inline', false)}
     />
   ))
   .add('With Container', () => (
@@ -23,4 +24,17 @@ stories
         size={getSizes()}
       />
     </SpinnerContainer>
+  ))
+  .add('With Container convenience prop', () => (
+    <Spinner container />
+  ))
+  .add('Inline Spinner', () => (
+    <div>
+      <span>Lorem Ipsum</span>
+      <Spinner
+        size="x-small"
+        inline
+      />
+      <Button>foo bar</Button>
+    </div>
   ));

--- a/stories/Tabs.js
+++ b/stories/Tabs.js
@@ -15,6 +15,7 @@ stories
       scoped={boolean('Scoped?', false)}
       onChangeTab={action('change-tab')}
       renderInactiveTabs={boolean('Render Inactive Tabs (Inspect to see change)', false)}
+      size={select('Size', ['', 'medium', 'large'], '')}
     >
       <Tab id="tab-1" title="Tab 1">Tab One</Tab>
       <Tab id="tab-2" title="Tab 2">

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@salesforce-ux/design-system@2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@salesforce-ux/design-system/-/design-system-2.5.2.tgz#454f2c0b0214a980b10fe817061c4b8c15c35276"
-  integrity sha512-VPjwUPj0er0bwH/7U4FGJUiVTRJtyVjvDdFFWRBalFubKgx8hAj7WiIMrdWmofyADmsFDI9aomsDHZvjf7CKeQ==
+"@salesforce-ux/design-system@~2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@salesforce-ux/design-system/-/design-system-2.7.4.tgz#dabf45767128389ded9fb7bd34c19fcf4614ec17"
+  integrity sha512-3dbl05b/132UvSq1lEslLC+gTghyc13Q11zYrZx0MSoO6zOgMSCfL9qHi3AieU4JvCMV93V3mAugObXWfrpWjA==
 
 "@storybook/addon-actions@^3.2.19":
   version "3.3.10"


### PR DESCRIPTION
 - [x] *ButtonGroup*: Add row variant
 - [x] *Accordion*: Remove spacing tokens from heading
 - [x] *Alert/Toast*: Update markup, update aria-roles
 - [x] *Button*: Add text-destructive variant
 - [x] *Stateful Button*: Remove deprecated classes
 - [x] *Avatar*: Add bindings for new variants and fallbacks
 - [x] Button: Added slds-button_outline-brand modifie
 - [x] *Tabs*: Added slds-tabs_medium and slds-tabs_large to modify the font-size and spacing of the tab items
 - [x] *Carousel*: Swapped values for aria-hidden on Carousel panels
 - [x] ~*Icons*: 
    Icons can now be filled with the success text color by adding slds-icon-text 
 success~ Covered by `svgClassname`
 - [x] ~*Expandable Section*: Replaced spacing tokens with variable spacing tokens to respond to a user's densification setting~ Internal change
 - [x] ~*Checkbox Button*: Added an example of a checked-and-disabled checkbox button~ Not implemented in this project
 - [x] *Card*: Added slds-card__footer-action to have footer link take up full width of card 
 - [x] *Files*: New class slds-file_loading for loading state. 
 - [x] *Files*: lass slds-has-title for when Files have a title applied. 
 - [x] *Progress Bar*: Add vertical progress bars
 - [x] *Progress Bar*: Added an example of descriptive progress bar with label and progress percentage above bar 
 - [x] *Form Element*: Added slds-form-element__readonly to apply appropiate styling when a form element is in view mode
 - [x] *Form Element*: Left aligned label support for components with help text icon and required asterisk
 - [x] *Form Element*: Left aligned label support for fieldset and legend form elements
 - [x] *Grid*: Added slds-gutters_direct for adding gutters to direct child columns of a grid. 
 - [x] *Popovers*: 
    Added slds-nubbin_*-corner modifier classes to place nubbin elements at the corner of a Popover.
 - [x] *Page Headers*: Lot of changes
 - [x] *Data Tables*: Added a hidden header variation of the data table 
 - [x] ~*Data Tables*: Data tables underwent some minor markup changes to help align all the different variants to use common markup patterns. No visual styling or functionality has changed, but you will notice more examples.~ Nothing major, can tackle later
 - [x] *Combobox*: Added slds-listbox__option-icon to be used as a container that maintains the dimensions of an icon when it is removed from the HTML
 - [x] ~*Tabs*: Added mobile tabs~ Out of scope, move to ticket
 - [x] *Progress Ring*: Added an example of a progress ring that fills rather than drains, meaning the colored portion of the ring increases clockwise.
 - [x] *Progress Ring*: Added slds-progress-ring_large modifier to make a 32x32px ring 
 - [x] *Progress Ring*: Added slds-progress-ring_active-step modifier to change color of progress ring
 - [x] *Spinner*: Added inline spinner
