### PR TITLE
Remove scroll wrapper for sticky headers in tables

### DIFF
--- a/src/components/DataTable/__tests__/DataTable.spec.js
+++ b/src/components/DataTable/__tests__/DataTable.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { DataTable, DataTableColumn, DataTableSelectColumn } from '..';
-import { Cell } from '../../Table';
+import { Row } from '../../Table';
 
 describe('<DataTable />', () => {
   const getComponent = (props, selectable, nameProps, ageProps) => {
@@ -166,10 +166,6 @@ describe('<DataTable />', () => {
   it('displays a sticky header and adds an additional scroll container', () => {
     const mounted = getComponent({ stickyHeader: true }, false);
 
-    expect(mounted.find('.slds-scrollable')).toHaveLength(1);
-
-    expect(mounted.find('th').at(0).prop('style')).toEqual(Cell.STICKY_TOP_STYLE);
-    mounted.setState({ isScrolled: true });
-    expect(mounted.find('th').at(0).prop('style')).toEqual(Cell.STICKY_SCROLLED_STYLE);
+    expect(mounted.find('thead').find(Row).prop('style')).toEqual(Row.STICKY_TOP_STYLE);
   });
 });

--- a/src/components/DataTable/defaultHeadRenderer.js
+++ b/src/components/DataTable/defaultHeadRenderer.js
@@ -6,8 +6,6 @@ import { Cell } from '../..';
 /* eslint-disable react/prop-types */
 export default ({
   dataKey,
-  isScrolled,
-  isSticky,
   onSort,
   sortable,
   sortBy,
@@ -20,8 +18,6 @@ export default ({
   return (
     <Cell
       className={classNames}
-      isScrolled={isScrolled}
-      isSticky={isSticky}
       key={dataKey}
       onClick={onClick}
       scope="col"

--- a/src/components/DataTable/defaultSelectAllRenderer.js
+++ b/src/components/DataTable/defaultSelectAllRenderer.js
@@ -1,28 +1,20 @@
 import React from 'react';
-import { CheckboxRaw, Cell } from '../..';
+import { CheckboxRaw } from '../..';
 
 /* eslint-disable react/prop-types */
 export default ({
   allSelected,
   dataKey,
-  isScrolled,
-  isSticky,
   onSelectAll,
   tableId,
 }) => {
   const checkboxId = `${tableId}-${dataKey}`;
-
-  let style = null;
-  if (isSticky) {
-    style = isScrolled ? Cell.STICKY_SCROLLED_STYLE : Cell.STICKY_TOP_STYLE;
-  }
 
   return (
     <th
       className="slds-text-align--right"
       key={dataKey}
       scope="col"
-      style={style}
     >
       <div>
         <CheckboxRaw

--- a/src/components/Table/Cell.js
+++ b/src/components/Table/Cell.js
@@ -9,8 +9,6 @@ const Cell = (props) => {
   const {
     children,
     className,
-    isScrolled,
-    isSticky,
     resizable,
     resizableAssistiveText,
     scope,
@@ -126,18 +124,12 @@ const Cell = (props) => {
 
   const wrappedChildren = wrapChildren(childArray);
   const wrapperClassName = cx({ 'slds-truncate': truncate });
-  const isHeaderSticky = isHeader && isSticky;
-  let style = null;
-  if (isHeaderSticky) {
-    style = isScrolled ? Cell.STICKY_SCROLLED_STYLE : Cell.STICKY_TOP_STYLE;
-  }
 
   return (
     <CellElement
       {...rest}
       className={cx(sldsClasses)}
       scope={cellScope}
-      style={style}
     >
       <div className={wrapperClassName} title={cellTitle}>
         {wrappedChildren}
@@ -146,22 +138,9 @@ const Cell = (props) => {
   );
 };
 
-Cell.STICKY_TOP_STYLE = {
-  position: 'sticky',
-  top: 0,
-  zIndex: 1,
-};
-
-Cell.STICKY_SCROLLED_STYLE = {
-  ...Cell.STICKY_TOP_STYLE,
-  borderBottom: '1px solid rgb(221, 219, 218)',
-};
-
 Cell.defaultProps = {
   children: null,
   className: null,
-  isScrolled: false,
-  isSticky: false,
   resizable: false,
   resizableAssistiveText: 'Resize Cell',
   scope: null,
@@ -182,14 +161,6 @@ Cell.propTypes = {
    * class name
    */
   className: PropTypes.string,
-  /**
-   * Whether the table has been scrolled
-   */
-  isScrolled: PropTypes.bool,
-  /**
-   * Whether the cell is a sticky header cell
-   */
-  isSticky: PropTypes.bool,
   /**
    * makes the cell resizable
    */

--- a/src/components/Table/Row.js
+++ b/src/components/Table/Row.js
@@ -4,23 +4,40 @@ import cx from 'classnames';
 
 const Row = (props) => {
   const {
-    children, className, head, variation, ...rest
+    children,
+    className,
+    sticky,
+    variation,
+    ...rest
   } = props;
 
-  const variationClasses = Array.isArray(variation) ? variation.map(f => `slds-${f}`) : `slds-${variation}`;
+  const rowStyle = sticky ? Row.STICKY_SCROLLED_STYLE : null;
 
-  const sldsClasses = [
-    variationClasses,
-    className
-  ];
+  const variationClasses = Array.isArray(variation)
+    ? variation.map(f => `slds-${f}`)
+    : `slds-${variation}`;
 
-  return (<tr {...rest} className={cx(sldsClasses)}>{children}</tr>);
+  return (
+    <tr
+      {...rest}
+      className={cx([variationClasses, className])}
+      style={rowStyle}
+    >
+      {children}
+    </tr>
+  );
+};
+
+Row.STICKY_SCROLLED_STYLE = {
+  position: 'sticky',
+  top: 0,
+  zIndex: 1,
 };
 
 Row.defaultProps = {
   children: null,
   className: null,
-  head: false,
+  sticky: false,
   variation: [],
 };
 
@@ -34,9 +51,9 @@ Row.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * marks a header row
+   * Should only be set for rows nested in thead. Sets `position:sticky` to attach to top of the scrolling ctx
    */
-  head: PropTypes.bool,
+  sticky: PropTypes.bool,
   /**
    * variation: string or array of strings. Variations: is-selected, hint-parent
    */

--- a/stories/DataTable.js
+++ b/stories/DataTable.js
@@ -2,7 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
-import { array, object, select, text } from '@storybook/addon-knobs';
+import {
+  array,
+  object,
+  select,
+  text,
+} from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import {
   Button,
@@ -73,7 +78,8 @@ stories
       height: '300px',
       width: '100%',
       display: 'flex',
-      flexDirection: 'column'
+      flexDirection: 'column',
+      overflowY: 'scroll'
     }}
     >
       <DataTable
@@ -103,7 +109,22 @@ stories
         />
       </DataTable>
     </div>
-  ))
+  ), {
+    info: `
+      This variant requires you to have a DOM ancestor that sets \`overflow-y: auto|scroll \`. \n
+      To optionally fix the double border for the first item, add the following to your CSS:
+      \`\`\` css
+      // CSS
+      .reactlds-table_stickyheader th {
+        border-bottom: 1px solid rgb(221, 219, 218); // $color-border-separator-alt
+      }
+
+      .reactlds-table_stickyheader tbody > tr:first-child > td {
+        border-top: none;
+      }
+      \`\`\`
+    `
+  })
   .add('Sortable table', withInfo(`
     Marking a column **sortable** will make the table header clickable. On click, the
     data array is sorted by that column. If an **onSort** callback is provided, sorting the

--- a/stories/utils/global.css
+++ b/stories/utils/global.css
@@ -23,3 +23,11 @@
   align-items: center;
   justify-content: center;
 }
+
+.reactlds-table_stickyheader th {
+  border-bottom: 1px solid rgb(221, 219, 218);
+}
+
+.reactlds-table_stickyheader tbody > tr:first-child > td {
+  border-top: none;
+}


### PR DESCRIPTION
* Remove in favor of CSS-based solution
* Allow  nesting in arbitrary scrolling ctx