### PR TITLE
Fix child rendering in ControlledMenu

### DIFF
--- a/src/components/Menu/ControlledMenu.js
+++ b/src/components/Menu/ControlledMenu.js
@@ -11,10 +11,6 @@ const propTypes = {
    */
   button: PropTypes.element.isRequired,
   /**
-   * set to true if menuitems should be menuitemcheckboxes
-   */
-  checkbox: PropTypes.bool,
-  /**
    * should be MenuItems or MenuSubHeaders
    */
   children: PropTypes.node.isRequired,
@@ -81,7 +77,6 @@ class ControlledMenu extends Component {
 
   static defaultProps = {
     className: null,
-    checkbox: false,
     height: null,
     heightIcon: null,
     isOpen: false,
@@ -104,24 +99,13 @@ class ControlledMenu extends Component {
   };
 
   renderChildren = () => {
-    const { children, checkbox } = this.props;
+    const { children } = this.props;
     return React.Children.map(children, (child, index) => {
       const id = getUniqueHash('item', index);
 
       if (!child) return null;
 
-      if (child.type !== MenuItem) {
-        return React.cloneElement(child, {
-          key: id
-        });
-      }
-
-      return React.cloneElement(
-        child, {
-          selected: checkbox ? child.props.selected === true : null,
-          key: id,
-        }
-      );
+      return React.cloneElement(child, { key: id });
     });
   };
 


### PR DESCRIPTION
@fspoettel I stumbled upon an inconsistency when rendering child components inside a `Menu`. Locally, condition https://github.com/propertybase/react-lds/compare/fix-controlled-menu?expand=1#diff-e75026ec5544dc1bd4f13c5484b4ee42L113 (`ƒ MenuItem(props) {...}`) is truthy and the selected state is applied correctly but in the live version https://github.com/propertybase/react-lds/compare/fix-controlled-menu?expand=1#diff-e75026ec5544dc1bd4f13c5484b4ee42L119 (`ƒ (e){...}`) gets executed and requires the `checkbox` prop. Can we get rid of that inconsistent check or is there a reason I'm not seeing? 