### PR TITLE
Add optional pin button to ObjectHome

### DIFF
--- a/src/components/PageHeader/ObjectHome.js
+++ b/src/components/PageHeader/ObjectHome.js
@@ -7,6 +7,7 @@ import { ControlledMenu } from '../Menu';
 import { IconButton } from '../Button';
 import { MediaObject } from '../MediaObject';
 import { Icon } from '../Icon';
+import { Grid } from '../Grid';
 
 class ObjectHome extends Component {
   static propTypes = {
@@ -51,6 +52,13 @@ class ObjectHome extends Component {
      */
     titleMenu: PropTypes.node,
     /**
+     * optional title menu action that gets displayed beside the header menu.
+     *
+     * TODO The SLDS does not yet provide the specifications for the pin button,
+     * once it does the structure should be updated accordingly.
+     */
+    titleMenuAction: PropTypes.node,
+    /**
      * top Buttons or ButtonGroup(s)
      */
     topButtons: PropTypes.node,
@@ -64,6 +72,7 @@ class ObjectHome extends Component {
     icon: null,
     info: null,
     titleMenu: null,
+    titleMenuAction: null,
     topButtons: null,
   }
 
@@ -93,6 +102,7 @@ class ObjectHome extends Component {
       recordType,
       title,
       titleMenu,
+      titleMenuAction,
       topButtons,
       ...rest
     } = this.props;
@@ -133,26 +143,36 @@ class ObjectHome extends Component {
                   </h1>
                 </div>
                 {titleMenu && (
-                  <ClickOutside
-                    className="slds-page-header__name-switcher"
-                    onClickOutside={this.onClickOutside}
-                    condition={closeOnClickOutside && menuIsOpen}
-                  >
-                    <ControlledMenu
-                      button={(
-                        <IconButton
-                          container
-                          icon="down"
-                          size="small"
-                          sprite="utility"
-                          onClick={this.toggleMenu}
-                        />
-                      )}
-                      isOpen={this.state.menuIsOpen}
+                  <React.Fragment>
+                    <ClickOutside
+                      className="slds-page-header__name-switcher"
+                      onClickOutside={this.onClickOutside}
+                      condition={closeOnClickOutside && menuIsOpen}
                     >
-                      {titleMenu}
-                    </ControlledMenu>
-                  </ClickOutside>
+                      <ControlledMenu
+                        button={(
+                          <IconButton
+                            container
+                            icon="down"
+                            size="small"
+                            sprite="utility"
+                            onClick={this.toggleMenu}
+                          />
+                        )}
+                        isOpen={this.state.menuIsOpen}
+                      >
+                        {titleMenu}
+                      </ControlledMenu>
+                    </ClickOutside>
+                    {titleMenuAction && (
+                      <Grid
+                        className="slds-p-left_xx-small"
+                        verticalAlign="end"
+                      >
+                        {titleMenuAction}
+                      </Grid>
+                    )}
+                  </React.Fragment>
                 )}
               </div>
             </MediaObject>

--- a/src/components/PageHeader/__tests__/ObjectHome.spec.js
+++ b/src/components/PageHeader/__tests__/ObjectHome.spec.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import ObjectHome from '../ObjectHome';
 import MenuItem from '../../Menu/MenuItem';
+import { IconButton } from '../../Button';
 
 describe('<ObjectHome />', () => {
   let mounted;
@@ -12,6 +13,15 @@ describe('<ObjectHome />', () => {
       <ObjectHome
         title="foo"
         titleMenu={<MenuItem>test123</MenuItem>}
+        titleMenuAction={(
+          <IconButton
+            border="filled"
+            icon="pin"
+            onClick={Function.prototype}
+            size="small"
+            sprite="utility"
+          />
+        )}
         recordType="unicornz"
         info="yeah"
         topButtons="button098"
@@ -64,5 +74,9 @@ describe('<ObjectHome />', () => {
     mounted.setProps({ className: 'foo', 'data-test': 'bar' });
     expect(mounted.find('.slds-page-header').hasClass('foo')).toBeTruthy();
     expect(mounted.find('.slds-page-header').prop('data-test')).toEqual('bar');
+  });
+
+  it('renders a pin button besides the header menu', () => {
+    expect(mounted.find(IconButton).at(1).prop('icon')).toEqual('pin');
   });
 });

--- a/stories/PageHeader.js
+++ b/stories/PageHeader.js
@@ -112,6 +112,15 @@ stories
       info={text('Info', '10 items • sorted by name')}
       icon={object('Icon', { icon: 'user', sprite: 'standard' })}
       bottomButtons={bottomButtons}
+      titleMenuAction={(
+        <IconButton
+          border="filled"
+          icon="pin"
+          onClick={Function.prototype}
+          size="small"
+          sprite="utility"
+        />
+      )}
     />
   ))
   .add('ObjectHome without menu', () => (


### PR DESCRIPTION
![Screenshot 2019-09-25 at 14 18 21](https://user-images.githubusercontent.com/511551/65601964-5e85c880-dfa3-11e9-95be-4a8ac584db45.png)
Custom implementation to allow adding a bin button to `ObjectHome` until the specifications of the SLDS get updated: https://lightningdesignsystem.com/components/page-headers/#site-main-content